### PR TITLE
rename job and clean up workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,20 +1,12 @@
-# This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
-
-name: Maven Package
+name: Maven Verify
 
 on:
   pull_request:
     branches: [master]
 
 jobs:
-  build:
-
+  verify:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 11
@@ -22,9 +14,6 @@ jobs:
       with:
         java-version: '11'
         distribution: 'temurin'
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
 
-    - name: Build with Maven
-      run: mvn -B package --file pom.xml
-      
+    - name: Verify with Maven
+      run: mvn -B verify -f pom.xml


### PR DESCRIPTION
Rename build workflow to verify. No need to package, compiling the project and running the tests should be enough to tests PRs.