### PR TITLE
Optionally use default values in builder

### DIFF
--- a/src/main/java/com/gluonhq/Main.java
+++ b/src/main/java/com/gluonhq/Main.java
@@ -14,10 +14,13 @@ import javafx.scene.text.Font;
 import javafx.scene.text.FontPosture;
 import javafx.scene.text.FontWeight;
 import javafx.stage.Stage;
+import javafx.util.StringConverter;
 import org.kordamp.ikonli.Ikon;
 import org.kordamp.ikonli.javafx.FontIcon;
-import org.kordamp.ikonli.lineawesome.LineAwesomeRegular;
 import org.kordamp.ikonli.lineawesome.LineAwesomeSolid;
+
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class Main extends Application {
 
@@ -33,11 +36,36 @@ public class Main extends Application {
 
         ComboBox<String> fontFamilies = new ComboBox<>();
         fontFamilies.getItems().setAll(Font.getFamilies());
-        fontFamilies.setOnAction( e -> {
+        fontFamilies.setValue("Arial");
+        fontFamilies.setOnAction(e -> {
             String ff = fontFamilies.getSelectionModel().getSelectedItem();
             Action action = editor.getActionFactory().decorateText(TextDecoration.builder().fontFamily(ff).build());
             editor.execute(action);
-        } );
+        });
+
+        final ComboBox<Double> fontSize = new ComboBox<>();
+        fontSize.setEditable(true);
+        fontSize.setPrefWidth(60);
+        fontSize.getItems().addAll(IntStream.range(1, 100)
+                .filter(i -> i % 2 == 0 || i < 10)
+                .asDoubleStream().boxed().collect(Collectors.toList()));
+        fontSize.setValue(17.0);
+        fontSize.setOnAction(e -> {
+            final Double fontSizeValue = fontSize.getValue();
+            final Action action = editor.getActionFactory().decorateText(TextDecoration.builder().fontSize(fontSizeValue).build());
+            editor.execute(action);
+        });
+        fontSize.setConverter(new StringConverter<>() {
+            @Override
+            public String toString(Double aDouble) {
+                return Integer.toString(aDouble.intValue());
+            }
+
+            @Override
+            public Double fromString(String s) {
+                return Double.parseDouble(s);
+            }
+        });
 
         final ColorPicker fontForeground = new ColorPicker();
         fontForeground.setOnAction(e -> {
@@ -55,6 +83,7 @@ public class Main extends Application {
                 actionButton(LineAwesomeSolid.PASTE, editor.getActionFactory().paste()),
                 new Separator(Orientation.VERTICAL),
                 fontFamilies,
+                fontSize,
                 actionButton(LineAwesomeSolid.BOLD, editor.getActionFactory().decorateText(TextDecoration.builder().fontWeight(FontWeight.BOLD).build())),
                 actionButton(LineAwesomeSolid.ITALIC, editor.getActionFactory().decorateText(TextDecoration.builder().fontPosture(FontPosture.ITALIC).build())),
                 fontForeground,

--- a/src/main/java/com/gluonhq/richtext/model/Piece.java
+++ b/src/main/java/com/gluonhq/richtext/model/Piece.java
@@ -14,7 +14,7 @@ public final class Piece {
     final TextDecoration decoration;
 
     public Piece(final PieceTable source, final BufferType bufferType, final int start, final int length) {
-        this(source, bufferType, start, length, TextDecoration.builder().build());
+        this(source, bufferType, start, length, null);
     }
 
     public Piece(final PieceTable source, final BufferType bufferType, final int start, final int length, TextDecoration decoration) {
@@ -23,7 +23,7 @@ public final class Piece {
         this.start = start;
         this.length = Math.max(length, 0);
         this.source = Objects.requireNonNull(source);
-        this.decoration = decoration == null ? TextDecoration.builder().build() : decoration;
+        this.decoration = decoration == null ? TextDecoration.builder().buildDefault() : decoration;
 
 
         // find all the line stops
@@ -64,7 +64,7 @@ public final class Piece {
     }
 
     Piece copy(int newStart, int newLength, TextDecoration textDecoration) {
-        return new Piece(source, bufferType, newStart, newLength, textDecoration.normalize(decoration));
+        return new Piece(source, bufferType, newStart, newLength, textDecoration);
     }
 
     // excludes char at offset

--- a/src/main/java/com/gluonhq/richtext/model/PieceTable.java
+++ b/src/main/java/com/gluonhq/richtext/model/PieceTable.java
@@ -588,17 +588,17 @@ class TextDecorateCmd extends AbstractCommand<PieceTable> {
                     if (offset > 0) {
                         additions.add(piece.pieceBefore(offset));
                     }
-                    additions.add(piece.copy(piece.start + offset, length, decoration));
+                    additions.add(piece.copy(piece.start + offset, length, decoration.normalize(piece.getDecoration())));
                     if (end < textPosition + piece.length) {
                         additions.add(piece.pieceFrom(end - textPosition));
                     }
                     removals.add(piece);
                 }  else if (textPosition + piece.length <= end) { // entire piece is in selection
-                    additions.add(piece.copy(piece.start, piece.length, decoration));
+                    additions.add(piece.copy(piece.start, piece.length, decoration.normalize(piece.getDecoration())));
                     removals.add(piece);
                 } else if (textPosition < end) {
                     int offset = end - textPosition;
-                    additions.add(piece.copy(piece.start, offset, decoration));
+                    additions.add(piece.copy(piece.start, offset, decoration.normalize(piece.getDecoration())));
                     additions.add(piece.pieceFrom(offset));
                     removals.add(piece);
                 }

--- a/src/main/java/com/gluonhq/richtext/model/TextDecoration.java
+++ b/src/main/java/com/gluonhq/richtext/model/TextDecoration.java
@@ -58,23 +58,26 @@ public class TextDecoration {
             return this;
         }
         TextDecoration td = new TextDecoration();
-        td.foreground  = foreground;
-        td.background  = background;
-        td.fontFamily  = fontFamily;
-        td.fontSize    = fontSize;
-        td.fontWeight  = fontWeight == decoration.getFontWeight() ? FontWeight.NORMAL : fontWeight;
-        td.fontPosture = fontPosture == decoration.getFontPosture() ? FontPosture.REGULAR : fontPosture;
+        final double normalizedFontSize = this.fontSize < 1.0 ? decoration.getFontSize() : this.fontSize;
+        final FontWeight normalizedWeight = this.fontWeight == decoration.getFontWeight() ? FontWeight.NORMAL : this.fontWeight;
+        final FontPosture normalizedPosture = this.fontPosture == decoration.getFontPosture() ? FontPosture.REGULAR : this.fontPosture;
+        td.foreground  = Objects.requireNonNullElse(foreground, decoration.getForeground());
+        td.background  = Objects.requireNonNullElse(background, decoration.getBackground());
+        td.fontFamily  = Objects.requireNonNullElse(fontFamily, decoration.getFontFamily());
+        td.fontSize    = normalizedFontSize;
+        td.fontWeight  = Objects.requireNonNullElse(normalizedWeight, decoration.getFontWeight());
+        td.fontPosture = Objects.requireNonNullElse(normalizedPosture, decoration.getFontPosture());
         return td;
     }
 
     public static class Builder {
 
-        private Color foreground = Color.BLUE;
-        private Color background = Color.BLUE;
-        private String fontFamily = "Arial";
-        private double fontSize = 17.0;
-        private FontPosture fontPosture = FontPosture.REGULAR;
-        private FontWeight fontWeight = FontWeight.MEDIUM;
+        private Color foreground;
+        private Color background;
+        private String fontFamily;
+        private double fontSize;
+        private FontPosture fontPosture;
+        private FontWeight fontWeight;
 
         private Builder() {}
 
@@ -87,6 +90,16 @@ public class TextDecoration {
             decoration.fontWeight  = this.fontWeight;
             decoration.fontPosture = this.fontPosture;
             return decoration;
+        }
+
+        public TextDecoration buildDefault() {
+            foreground = Color.BLUE;
+            background = Color.BLUE;
+            fontFamily = "Arial";
+            fontSize = 17.0;
+            fontPosture = FontPosture.REGULAR;
+            fontWeight = FontWeight.MEDIUM;
+            return build();
         }
 
         public Builder foreground(Color color) {


### PR DESCRIPTION
TextDecoration object currently has defaults set in it.

Say, we have a text with following text decoration:

```
TextDecoration { fontWeight=BOLD, fontPosture=REGULAR }
```

And then the user applies ITALIC posture to it. Since, we have defaults set, TextDecoration definition generated by the builder would be:

```
TextDecoration { fontWeight=NORMAL, fontPosture=ITALIC }
```

Now, there is no way to identify if `fontWeight=NORMAL` was set by the user and it  to be applied or not?

The current PR updates `TextDecoration.Builder` to not set default values. Instead `buildDefault()` method can be used if the developer wants to get default values.

This enables developers to create `TextDecoration` objects with just setting the desired attribute:

```
TextDecoration { fontWeight=null, fontPosture=ITALIC }
```

This single attribute can now be applied on Text with existing attributes like font weight or color.

