### PR TITLE
Add java Logger

### DIFF
--- a/src/main/java/com/gluonhq/Main.java
+++ b/src/main/java/com/gluonhq/Main.java
@@ -19,10 +19,25 @@ import org.kordamp.ikonli.Ikon;
 import org.kordamp.ikonli.javafx.FontIcon;
 import org.kordamp.ikonli.lineawesome.LineAwesomeSolid;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class Main extends Application {
+
+    static {
+        try (InputStream resourceAsStream = Main.class.getResourceAsStream("/logging.properties")) {
+            if (resourceAsStream != null) {
+                LogManager.getLogManager().readConfiguration(resourceAsStream);
+            }
+        } catch (IOException ex) {
+            Logger.getLogger(Main.class.getName()).log(Level.SEVERE, "Error opening logging.properties file", ex);
+        }
+    }
 
     private final Label textLengthLabel = new Label();
     private final RichTextArea editor = new RichTextArea();

--- a/src/main/java/com/gluonhq/richtext/Tools.java
+++ b/src/main/java/com/gluonhq/richtext/Tools.java
@@ -30,4 +30,11 @@ public class Tools {
         if (value > max) return max;
         return value;
     }
+
+    public static String getFirstLetter(String name) {
+        if (name == null || name.isEmpty()) {
+            return "-";
+        }
+        return name.substring(0, 1);
+    }
 }

--- a/src/main/java/com/gluonhq/richtext/model/Piece.java
+++ b/src/main/java/com/gluonhq/richtext/model/Piece.java
@@ -2,6 +2,8 @@ package com.gluonhq.richtext.model;
 
 import java.util.Objects;
 
+import static com.gluonhq.richtext.Tools.getFirstLetter;
+
 public final class Piece {
 
     public enum BufferType {ORIGINAL, ADDITION}
@@ -81,7 +83,7 @@ public final class Piece {
 
     @Override
     public String toString() {
-        return "Piece{type=" + (bufferType == BufferType.ORIGINAL ? "O" : "A") +
+        return "Piece{type=" + getFirstLetter(bufferType.name()) +
                 ", [" + start +
                 ", " + length +
                 "], " + decoration +

--- a/src/main/java/com/gluonhq/richtext/model/TextDecoration.java
+++ b/src/main/java/com/gluonhq/richtext/model/TextDecoration.java
@@ -6,6 +6,8 @@ import javafx.scene.text.FontWeight;
 
 import java.util.Objects;
 
+import static com.gluonhq.richtext.Tools.getFirstLetter;
+
 public class TextDecoration {
 
     private Color foreground;
@@ -98,7 +100,7 @@ public class TextDecoration {
             fontFamily = "Arial";
             fontSize = 17.0;
             fontPosture = FontPosture.REGULAR;
-            fontWeight = FontWeight.MEDIUM;
+            fontWeight = FontWeight.NORMAL;
             return this;
         }
 
@@ -139,8 +141,8 @@ public class TextDecoration {
                 "color=" + foreground +
                 ", font['" + fontFamily + '\'' +
                 ", " + fontSize +
-                ", " + (fontPosture == FontPosture.REGULAR ? "R" : "I") +
-                ", " + (fontWeight == FontWeight.NORMAL ? "N" : "B") +
+                ", " + getFirstLetter(fontPosture.name()) +
+                ", " + getFirstLetter(fontWeight.name()) +
                 "]}";
     }
 }

--- a/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
@@ -1,9 +1,7 @@
 package com.gluonhq.richtext.viewmodel;
 
-import com.gluonhq.richtext.EditorAction;
 import com.gluonhq.richtext.Selection;
 import com.gluonhq.richtext.Tools;
-import com.gluonhq.richtext.Action;
 import com.gluonhq.richtext.model.TextBuffer;
 import com.gluonhq.richtext.model.TextDecoration;
 import com.gluonhq.richtext.undo.CommandManager;
@@ -14,21 +12,19 @@ import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
-import javafx.scene.input.KeyEvent;
 
 import java.text.BreakIterator;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-
-import static java.util.Map.entry;
-import static javafx.scene.text.FontPosture.ITALIC;
-import static javafx.scene.text.FontWeight.BOLD;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class RichTextAreaViewModel {
+
+    public static final Logger LOGGER = Logger.getLogger(RichTextAreaViewModel.class.getName());
 
     public enum Direction { FORWARD, BACK, UP, DOWN }
 
@@ -236,7 +232,7 @@ public class RichTextAreaViewModel {
     public void walkFragments(BiConsumer<String, TextDecoration> onFragment) {
         textBuffer.resetCharacterIterator();
         textBuffer.walkFragments(onFragment);
-        System.out.println(textBuffer);
+        LOGGER.log(Level.FINE, textBuffer.toString());
     }
 
     void undo() {

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,0 +1,7 @@
+handlers = java.util.logging.ConsoleHandler
+.level = INFO
+
+java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+com.gluonhq.richtext.viewmodel.level = INFO


### PR DESCRIPTION
Fixes #49 

The default logger is set for `com.gluonhq.richtext.viewmodel.level ` is set to `INFO`, so no logging is shown.
While developing locally, it can be set to `FINE` if needed, without the need to commit the change.