### PR TITLE
Add textAlignment property

### DIFF
--- a/src/main/java/com/gluonhq/richtext/RichTextArea.java
+++ b/src/main/java/com/gluonhq/richtext/RichTextArea.java
@@ -13,6 +13,7 @@ import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.Control;
 import javafx.scene.control.SkinBase;
+import javafx.scene.text.TextAlignment;
 
 import java.util.Objects;
 
@@ -107,6 +108,18 @@ public class RichTextArea extends Control {
 
     public final ActionFactory getActionFactory() {
         return actionFactory;
+    }
+
+    // textAlignmentProperty
+    private final ObjectProperty<TextAlignment> textAlignmentProperty = new SimpleObjectProperty<>(this, "textAlignment", TextAlignment.LEFT);
+    public final ObjectProperty<TextAlignment> textAlignmentProperty() {
+       return textAlignmentProperty;
+    }
+    public final TextAlignment getTextAlignment() {
+       return textAlignmentProperty.get();
+    }
+    public final void setTextAlignment(TextAlignment value) {
+        textAlignmentProperty.set(value);
     }
 
 }

--- a/src/main/java/com/gluonhq/richtext/RichTextAreaSkin.java
+++ b/src/main/java/com/gluonhq/richtext/RichTextAreaSkin.java
@@ -285,6 +285,7 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
             addBackgroundPathsToLayers(backgroundIndexRanges);
         } finally {
             if (updateText) {
+                fragments = null;
                 fontCacheEvictionTimer.start();
             }
         }

--- a/src/main/java/com/gluonhq/richtext/action/ActionFactory.java
+++ b/src/main/java/com/gluonhq/richtext/action/ActionFactory.java
@@ -3,6 +3,10 @@ package com.gluonhq.richtext.action;
 import com.gluonhq.richtext.RichTextArea;
 import com.gluonhq.richtext.model.TextDecoration;
 import com.gluonhq.richtext.viewmodel.ActionCmdFactory;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.event.ActionEvent;
+import javafx.scene.text.TextAlignment;
 
 public class ActionFactory {
 
@@ -55,5 +59,20 @@ public class ActionFactory {
 
     public Action decorate(TextDecoration decoration) {
         return new BasicAction(control, action -> ACTION_CMD_FACTORY.decorateText(decoration));
+    }
+
+    public Action align(TextAlignment alignment) {
+
+        return new Action() {
+            @Override
+            public void execute(ActionEvent event) {
+                control.setTextAlignment(alignment);
+            }
+
+            @Override
+            public ReadOnlyBooleanProperty disabledProperty() {
+                return new SimpleBooleanProperty(false);
+            }
+        };
     }
 }


### PR DESCRIPTION
Fixes #72 

This PR binds the RTA new `textAlignment` property to the same existing property for `TextFlow`. This implies that text alignment is applied equally to all text nodes, and not by paragraph.

Open questions:
- If we need the more fine grain control of alignment (i.e. paragraphs), we can’t use the TextFlow anymore, and we’ll need to reimplement it with such option.
- the TextAlignment property is applied to the control and not to the TextBuffer (so it is not part of the FaceModel). Should we make it part of the model?