### PR TITLE
Add new, open, save actions

### DIFF
--- a/src/main/java/com/gluonhq/Main.java
+++ b/src/main/java/com/gluonhq/Main.java
@@ -9,6 +9,7 @@ import com.gluonhq.richtext.model.FaceModel;
 import com.gluonhq.richtext.model.ImageDecoration;
 import com.gluonhq.richtext.model.TextDecoration;
 import javafx.application.Application;
+import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
@@ -94,6 +95,7 @@ public class Main extends Application {
         ComboBox<String> fontFamilies = new ComboBox<>();
         fontFamilies.getItems().setAll(Font.getFamilies());
         fontFamilies.setValue("Arial");
+        fontFamilies.setPrefWidth(100);
         new TextDecorateAction<>(editor, fontFamilies.valueProperty(), TextDecoration::getFontFamily, (builder, a) -> builder.fontFamily(a).build());
 
         final ComboBox<Double> fontSize = new ComboBox<>();
@@ -131,12 +133,16 @@ public class Main extends Application {
 
         ToolBar toolbar = new ToolBar();
         toolbar.getItems().setAll(
+                actionButton(LineAwesomeSolid.FILE,  editor.getActionFactory().newFaceModel()),
+                actionButton(LineAwesomeSolid.FOLDER_OPEN, editor.getActionFactory().open(faceModel)),
+                actionButton(LineAwesomeSolid.SAVE,  editor.getActionFactory().save()),
+                new Separator(Orientation.VERTICAL),
                 actionButton(LineAwesomeSolid.CUT,   editor.getActionFactory().cut()),
                 actionButton(LineAwesomeSolid.COPY,  editor.getActionFactory().copy()),
                 actionButton(LineAwesomeSolid.PASTE, editor.getActionFactory().paste()),
                 new Separator(Orientation.VERTICAL),
-                actionButton(LineAwesomeSolid.UNDO, editor.getActionFactory().undo()),
-                actionButton(LineAwesomeSolid.REDO, editor.getActionFactory().redo()),
+                actionButton(LineAwesomeSolid.UNDO,  editor.getActionFactory().undo()),
+                actionButton(LineAwesomeSolid.REDO,  editor.getActionFactory().redo()),
                 new Separator(Orientation.VERTICAL),
                 actionImage(LineAwesomeSolid.IMAGE),
                 new Separator(Orientation.VERTICAL),
@@ -156,14 +162,12 @@ public class Main extends Application {
         statusBar.setAlignment(Pos.CENTER_RIGHT);
         statusBar.getChildren().setAll(textLengthLabel);
 
-        MenuItem newFileMenu = new MenuItem("New Text");
-        newFileMenu.setOnAction(e -> editor.setFaceModel(new FaceModel()));
-        MenuItem openFileMenu = new MenuItem("Open Text");
-        // For now, just load a decorated text
-        openFileMenu.setOnAction(e -> editor.setFaceModel(faceModel));
-
         Menu fileMenu = new Menu("File");
-        fileMenu.getItems().addAll(newFileMenu, openFileMenu);
+        fileMenu.getItems().addAll(
+                actionMenuItem("New Text", LineAwesomeSolid.FILE, editor.getActionFactory().newFaceModel()),
+                actionMenuItem("Open Text", LineAwesomeSolid.FOLDER_OPEN, editor.getActionFactory().open(faceModel)),
+                new SeparatorMenuItem(),
+                actionMenuItem("Save Text", LineAwesomeSolid.SAVE, editor.getActionFactory().save()));
         Menu editMenu = new Menu("Edit");
         editMenu.getItems().addAll(
                 actionMenuItem("Undo", LineAwesomeSolid.UNDO, editor.getActionFactory().undo()),
@@ -179,9 +183,9 @@ public class Main extends Application {
         root.setTop(new VBox(menuBar, toolbar));
         root.setBottom(statusBar);
 
-        Scene scene = new Scene(root, 800, 480);
+        Scene scene = new Scene(root, 900, 480);
         scene.getStylesheets().add(Main.class.getResource("main.css").toExternalForm());
-        stage.setTitle("Rich Text Demo");
+        stage.titleProperty().bind(Bindings.createStringBinding(() -> "Rich Text Demo" + (editor.isModified() ? " *" : ""), editor.modifiedProperty()));
         stage.setScene(scene);
         stage.show();
 

--- a/src/main/java/com/gluonhq/richtext/RichTextArea.java
+++ b/src/main/java/com/gluonhq/richtext/RichTextArea.java
@@ -5,6 +5,8 @@ import com.gluonhq.richtext.model.FaceModel;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.property.ReadOnlyIntegerProperty;
 import javafx.beans.property.ReadOnlyIntegerWrapper;
 import javafx.beans.property.ReadOnlyObjectProperty;
@@ -39,7 +41,12 @@ public class RichTextArea extends Control {
     }
 
     // faceModelProperty
-    private final ObjectProperty<FaceModel> faceModelProperty = new SimpleObjectProperty<>(this, "faceModel", new FaceModel());
+    private final ObjectProperty<FaceModel> faceModelProperty = new SimpleObjectProperty<>(this, "faceModel", new FaceModel()) {
+        @Override
+        protected void invalidated() {
+            System.out.println(get());
+        }
+    };
     public final ObjectProperty<FaceModel> faceModelProperty() {
        return faceModelProperty;
     }
@@ -48,6 +55,15 @@ public class RichTextArea extends Control {
     }
     public final void setFaceModel(FaceModel value) {
         faceModelProperty.set(value);
+    }
+
+    // modifiedProperty
+    final ReadOnlyBooleanWrapper modifiedProperty = new ReadOnlyBooleanWrapper(this, "modified");
+    public final ReadOnlyBooleanProperty modifiedProperty() {
+       return modifiedProperty.getReadOnlyProperty();
+    }
+    public final boolean isModified() {
+       return modifiedProperty.get();
     }
 
     // editableProperty

--- a/src/main/java/com/gluonhq/richtext/RichTextAreaSkin.java
+++ b/src/main/java/com/gluonhq/richtext/RichTextAreaSkin.java
@@ -10,7 +10,6 @@ import com.gluonhq.richtext.viewmodel.ActionCmdFactory;
 import com.gluonhq.richtext.viewmodel.RichTextAreaViewModel;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
-import javafx.application.Platform;
 import javafx.beans.Observable;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.DoubleBinding;
@@ -137,7 +136,6 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
     private final Map<String, Image> imageCache = new ConcurrentHashMap<>();
     private final SmartTimer fontCacheEvictionTimer = new SmartTimer(this::evictUnusedFonts, 1000, 60000);
     private final SmartTimer imageCacheEvictionTimer = new SmartTimer(this::evictUnusedImages, 1000, 60000);
-    private final SmartTimer checkFaceModelTimer = new SmartTimer(this::checkFaceModel, 1000, 1000);
 
     private final Consumer<TextBuffer.Event> textChangeListener = e -> refreshTextFlow();
     private final ChangeListener<Boolean> focusChangeListener;
@@ -224,7 +222,6 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
 
     @Override
     public void dispose() {
-        checkFaceModelTimer.pause();
         viewModel.clearSelection();
         viewModel.caretPositionProperty().removeListener(caretPositionListener);
         viewModel.selectionProperty().removeListener(selectionListener);
@@ -271,7 +268,7 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
         viewModel.setFaceModel(faceModel);
         viewModel.faceModelProperty().addListener(faceModelChangeListener);
         getSkinnable().textLengthProperty.bind(viewModel.textLengthProperty());
-        getSkinnable().modifiedProperty.bind(viewModel.modifiedProperty());
+        getSkinnable().modifiedProperty.bind(viewModel.undoStackEmptyProperty().not());
         getSkinnable().setOnContextMenuRequested(contextMenuEventEventHandler);
         getSkinnable().editableProperty().addListener(this::editableChangeListener);
         getSkinnable().setOnKeyPressed(this::keyPressedListener);
@@ -290,7 +287,6 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
         refreshTextFlow();
         requestLayout();
         editableChangeListener(null); // sets up all related listeners
-        checkFaceModelTimer.start();
     }
 
     // TODO Need more optimal way of rendering text fragments.
@@ -413,13 +409,6 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
         List<Image> cachedImages = new ArrayList<>(imageCache.values());
         cachedImages.removeAll(usedImages);
         imageCache.values().removeAll(cachedImages);
-    }
-
-    private void checkFaceModel() {
-        final boolean modified = !viewModel.getCurrentFaceModel().equals(getSkinnable().getFaceModel());
-        if (modified != viewModel.isModified()) {
-            Platform.runLater(() -> viewModel.setModified(modified));
-        }
     }
 
     private void editableChangeListener(Observable o) {

--- a/src/main/java/com/gluonhq/richtext/RichTextAreaSkin.java
+++ b/src/main/java/com/gluonhq/richtext/RichTextAreaSkin.java
@@ -64,7 +64,6 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.gluonhq.richtext.model.FaceModel.EMPTY_FACE_MODEL;
 import static com.gluonhq.richtext.viewmodel.RichTextAreaViewModel.Direction;
 import static java.util.Map.entry;
 import static javafx.scene.input.KeyCode.*;
@@ -163,14 +162,13 @@ public class RichTextAreaSkin extends SkinBase<RichTextArea> {
     };
     private int nonTextNodesCount;
     private final ChangeListener<FaceModel> faceModelChangeListener = (obs, ov, nv) -> {
-        if (nv == null) {
-            return;
-        }
-        if (EMPTY_FACE_MODEL.equals(ov)) {
+        if (ov == null && nv != null) {
+            // new/open
             dispose();
             getSkinnable().setFaceModel(nv);
             setup(nv);
-        } else if (!EMPTY_FACE_MODEL.equals(nv)) {
+        } else if (nv != null) {
+            // save
             getSkinnable().setFaceModel(nv);
         }
     };

--- a/src/main/java/com/gluonhq/richtext/action/ActionFactory.java
+++ b/src/main/java/com/gluonhq/richtext/action/ActionFactory.java
@@ -2,6 +2,7 @@ package com.gluonhq.richtext.action;
 
 import com.gluonhq.richtext.RichTextArea;
 import com.gluonhq.richtext.model.Decoration;
+import com.gluonhq.richtext.model.FaceModel;
 import com.gluonhq.richtext.model.ImageDecoration;
 import com.gluonhq.richtext.model.TextDecoration;
 import com.gluonhq.richtext.viewmodel.ActionCmdFactory;
@@ -53,6 +54,26 @@ public class ActionFactory {
             paste = new BasicAction(control, action -> ACTION_CMD_FACTORY.paste());
         }
         return paste;
+    }
+
+    private Action newFaceModel;
+    public Action newFaceModel() {
+        if (newFaceModel == null) {
+            newFaceModel = new BasicAction(control, action -> ACTION_CMD_FACTORY.newFaceModel());
+        }
+        return newFaceModel;
+    }
+
+    public Action open(FaceModel faceModel) {
+        return new BasicAction(control, action -> ACTION_CMD_FACTORY.open(faceModel));
+    }
+
+    private Action save;
+    public Action save() {
+        if (save == null) {
+            save = new BasicAction(control, action -> ACTION_CMD_FACTORY.save());
+        }
+        return save;
     }
 
     public Action decorate(Decoration decoration) {

--- a/src/main/java/com/gluonhq/richtext/model/DecorationModel.java
+++ b/src/main/java/com/gluonhq/richtext/model/DecorationModel.java
@@ -1,5 +1,7 @@
 package com.gluonhq.richtext.model;
 
+import java.util.Objects;
+
 public class DecorationModel {
     private final int start;
     private final int length;
@@ -21,5 +23,27 @@ public class DecorationModel {
 
     public Decoration getDecoration() {
         return decoration;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DecorationModel that = (DecorationModel) o;
+        return start == that.start && length == that.length && decoration.equals(that.decoration);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(start, length, decoration);
+    }
+
+    @Override
+    public String toString() {
+        return "DecorationModel{" +
+                "start=" + start +
+                ", length=" + length +
+                ", decoration=" + decoration +
+                '}';
     }
 }

--- a/src/main/java/com/gluonhq/richtext/model/FaceModel.java
+++ b/src/main/java/com/gluonhq/richtext/model/FaceModel.java
@@ -1,6 +1,10 @@
 package com.gluonhq.richtext.model;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static com.gluonhq.richtext.model.PieceTable.ZERO_WIDTH_TEXT;
 
 public class FaceModel {
 
@@ -9,15 +13,15 @@ public class FaceModel {
     private final int caretPosition;
 
     public FaceModel() {
-        this("", null, 0);
+        this("");
     }
 
     public FaceModel(String text) {
-        this(text, null, 0);
+        this(text, 0);
     }
 
     public FaceModel(String text, int caretPosition) {
-        this(text, null, caretPosition);
+        this(text, List.of(new DecorationModel(0, text.length(), TextDecoration.builder().presets().build())), caretPosition);
     }
 
     public FaceModel(String text, List<DecorationModel> decorationList, int caretPosition) {
@@ -38,4 +42,26 @@ public class FaceModel {
         return caretPosition;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        FaceModel faceModel = (FaceModel) o;
+        return Objects.equals(text, faceModel.text) && Objects.equals(decorationList, faceModel.decorationList);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(text, decorationList, caretPosition);
+    }
+
+    @Override
+    public String toString() {
+        return "FaceModel{" +
+                "text='" + text.replaceAll("\n", "<n>").replaceAll(ZERO_WIDTH_TEXT, "<a>")  + '\'' +
+                ", decorationList=" + (decorationList == null ? "null" : "{" +
+                    decorationList.stream().map(decorationModel -> " - " + decorationModel.toString()).collect(Collectors.joining("\n", "\n", ""))) +
+                "\n}, caretPosition=" + caretPosition +
+                '}';
+    }
 }

--- a/src/main/java/com/gluonhq/richtext/model/FaceModel.java
+++ b/src/main/java/com/gluonhq/richtext/model/FaceModel.java
@@ -8,9 +8,6 @@ import static com.gluonhq.richtext.model.PieceTable.ZERO_WIDTH_TEXT;
 
 public class FaceModel {
 
-    private static final String EMPTY_TEXT = "\u0001";
-    public static FaceModel EMPTY_FACE_MODEL = new FaceModel(EMPTY_TEXT);
-
     private final String text;
     private final List<DecorationModel> decorationList;
     private final int caretPosition;

--- a/src/main/java/com/gluonhq/richtext/model/FaceModel.java
+++ b/src/main/java/com/gluonhq/richtext/model/FaceModel.java
@@ -8,6 +8,9 @@ import static com.gluonhq.richtext.model.PieceTable.ZERO_WIDTH_TEXT;
 
 public class FaceModel {
 
+    private static final String EMPTY_TEXT = "\u0001";
+    public static FaceModel EMPTY_FACE_MODEL = new FaceModel(EMPTY_TEXT);
+
     private final String text;
     private final List<DecorationModel> decorationList;
     private final int caretPosition;

--- a/src/main/java/com/gluonhq/richtext/model/ImageDecoration.java
+++ b/src/main/java/com/gluonhq/richtext/model/ImageDecoration.java
@@ -1,5 +1,7 @@
 package com.gluonhq.richtext.model;
 
+import java.util.Objects;
+
 public class ImageDecoration implements Decoration {
 
     private final int width;
@@ -40,6 +42,19 @@ public class ImageDecoration implements Decoration {
 
     public String getLink() {
         return link;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ImageDecoration that = (ImageDecoration) o;
+        return width == that.width && height == that.height && url.equals(that.url) && link.equals(that.link);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(width, height, url, link);
     }
 
     @Override

--- a/src/main/java/com/gluonhq/richtext/model/PieceTable.java
+++ b/src/main/java/com/gluonhq/richtext/model/PieceTable.java
@@ -92,6 +92,13 @@ public final class PieceTable extends AbstractTextBuffer {
     }
 
     @Override
+    public List<DecorationModel> getDecorationModelList() {
+        return pieces.stream()
+                .map(p -> new DecorationModel(p.start, p.length, p.getDecoration()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public CharacterIterator getCharacterIterator() {
         return pieceCharacterIterator;
     }

--- a/src/main/java/com/gluonhq/richtext/model/TextBuffer.java
+++ b/src/main/java/com/gluonhq/richtext/model/TextBuffer.java
@@ -3,6 +3,7 @@ package com.gluonhq.richtext.model;
 import javafx.beans.property.ReadOnlyIntegerProperty;
 
 import java.text.CharacterIterator;
+import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -12,6 +13,7 @@ public interface TextBuffer {
     ReadOnlyIntegerProperty textLengthProperty();
     String getText();
     String getText(int start, int end);
+    List<DecorationModel> getDecorationModelList();
 
     CharacterIterator getCharacterIterator();
     char charAt(int pos);

--- a/src/main/java/com/gluonhq/richtext/model/TextDecoration.java
+++ b/src/main/java/com/gluonhq/richtext/model/TextDecoration.java
@@ -81,6 +81,26 @@ public class TextDecoration implements Decoration {
         return td;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TextDecoration that = (TextDecoration) o;
+        return Double.compare(that.fontSize, fontSize) == 0 &&
+                Objects.equals(foreground, that.foreground) &&
+                Objects.equals(background, that.background) &&
+                Objects.equals(fontFamily, that.fontFamily) &&
+                fontPosture == that.fontPosture &&
+                fontWeight == that.fontWeight &&
+                Objects.equals(strikethrough, that.strikethrough) &&
+                Objects.equals(underline, that.underline);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(foreground, background, fontFamily, fontSize, fontPosture, fontWeight, strikethrough, underline);
+    }
+
     public static class Builder {
 
         private Color foreground;

--- a/src/main/java/com/gluonhq/richtext/undo/CommandManager.java
+++ b/src/main/java/com/gluonhq/richtext/undo/CommandManager.java
@@ -52,12 +52,12 @@ public class CommandManager<T> {
         }
     }
 
-    public boolean isUndoStackEmpty() {
-        return undoStack.isEmpty();
+    public int getUndoStackSize() {
+        return undoStack.size();
     }
 
-    public boolean isRedoStackEmpty() {
-        return redoStack.isEmpty();
+    public int getRedoStackSize() {
+        return redoStack.size();
     }
 
     public void clearStacks() {

--- a/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdFactory.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdFactory.java
@@ -1,5 +1,6 @@
 package com.gluonhq.richtext.viewmodel;
 
+import com.gluonhq.richtext.model.FaceModel;
 import com.gluonhq.richtext.model.ImageDecoration;
 import com.gluonhq.richtext.model.TextDecoration;
 import javafx.scene.input.KeyEvent;
@@ -12,6 +13,9 @@ public final class ActionCmdFactory {
 
     private final ActionCmd undo = new ActionCmdUndo();
     private final ActionCmd redo = new ActionCmdRedo();
+
+    private final ActionCmd newFaceModel = new ActionCmdNew();
+    private final ActionCmd save = new ActionCmdSave();
 
     private final ActionCmd selectAll = new ActionCmdSelectAll();
 
@@ -33,6 +37,18 @@ public final class ActionCmdFactory {
 
     public ActionCmd redo() {
         return redo;
+    }
+
+    public ActionCmd newFaceModel() {
+        return newFaceModel;
+    }
+
+    public ActionCmd open(FaceModel faceModel) {
+        return new ActionCmdOpen(faceModel);
+    }
+
+    public ActionCmd save() {
+        return save;
     }
 
     public ActionCmd selectAll() {

--- a/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdNew.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdNew.java
@@ -1,0 +1,10 @@
+package com.gluonhq.richtext.viewmodel;
+
+class ActionCmdNew implements ActionCmd {
+
+    @Override
+    public void apply(RichTextAreaViewModel viewModel) {
+        viewModel.newFaceModel();
+    }
+
+}

--- a/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdOpen.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdOpen.java
@@ -1,0 +1,18 @@
+package com.gluonhq.richtext.viewmodel;
+
+import com.gluonhq.richtext.model.FaceModel;
+
+class ActionCmdOpen implements ActionCmd {
+
+    private final FaceModel faceModel;
+
+    public ActionCmdOpen(FaceModel faceModel) {
+        this.faceModel = faceModel;
+    }
+
+    @Override
+    public void apply(RichTextAreaViewModel viewModel) {
+        viewModel.open(faceModel);
+    }
+
+}

--- a/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdRedo.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdRedo.java
@@ -14,7 +14,7 @@ class ActionCmdRedo implements ActionCmd {
 
     @Override
     public BooleanBinding getDisabledBinding(RichTextAreaViewModel viewModel) {
-        return Bindings.createBooleanBinding(() -> viewModel.isRedoStackEmpty() || !viewModel.isEditable(),
-                viewModel.redoStackEmptyProperty(), viewModel.editableProperty());
+        return Bindings.createBooleanBinding(() -> viewModel.getRedoStackSize() == 0 || !viewModel.isEditable(),
+                viewModel.redoStackSizeProperty(), viewModel.editableProperty());
     }
 }

--- a/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdSave.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdSave.java
@@ -11,6 +11,6 @@ class ActionCmdSave implements ActionCmd {
 
     @Override
     public BooleanBinding getDisabledBinding(RichTextAreaViewModel viewModel) {
-        return viewModel.textBufferProperty().isNull().or(viewModel.undoStackEmptyProperty());
+        return viewModel.textBufferProperty().isNull().or(viewModel.modifiedProperty().not());
     }
 }

--- a/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdSave.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdSave.java
@@ -11,6 +11,6 @@ class ActionCmdSave implements ActionCmd {
 
     @Override
     public BooleanBinding getDisabledBinding(RichTextAreaViewModel viewModel) {
-        return viewModel.textBufferProperty().isNull().or(viewModel.modifiedProperty().not());
+        return viewModel.textBufferProperty().isNull().or(viewModel.savedProperty());
     }
 }

--- a/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdSave.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdSave.java
@@ -11,6 +11,6 @@ class ActionCmdSave implements ActionCmd {
 
     @Override
     public BooleanBinding getDisabledBinding(RichTextAreaViewModel viewModel) {
-        return viewModel.textBufferProperty().isNull().or(viewModel.modifiedProperty().not());
+        return viewModel.textBufferProperty().isNull().or(viewModel.undoStackEmptyProperty());
     }
 }

--- a/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdSave.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdSave.java
@@ -1,0 +1,16 @@
+package com.gluonhq.richtext.viewmodel;
+
+import javafx.beans.binding.BooleanBinding;
+
+class ActionCmdSave implements ActionCmd {
+
+    @Override
+    public void apply(RichTextAreaViewModel viewModel) {
+        viewModel.save();
+    }
+
+    @Override
+    public BooleanBinding getDisabledBinding(RichTextAreaViewModel viewModel) {
+        return viewModel.textBufferProperty().isNull().or(viewModel.modifiedProperty().not());
+    }
+}

--- a/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdUndo.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdUndo.java
@@ -14,7 +14,7 @@ class ActionCmdUndo implements ActionCmd {
 
     @Override
     public BooleanBinding getDisabledBinding(RichTextAreaViewModel viewModel) {
-        return Bindings.createBooleanBinding(() -> viewModel.isUndoStackEmpty() || !viewModel.isEditable(),
-                viewModel.undoStackEmptyProperty(), viewModel.editableProperty());
+        return Bindings.createBooleanBinding(() -> viewModel.getUndoStackSize() == 0 || !viewModel.isEditable(),
+                viewModel.undoStackSizeProperty(), viewModel.editableProperty());
     }
 }

--- a/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
@@ -129,7 +129,7 @@ public class RichTextAreaViewModel {
 
     // undoStackSizeProperty
     final ReadOnlyBooleanWrapper undoStackEmptyProperty = new ReadOnlyBooleanWrapper(this, "undoStackEmpty", true);
-    ReadOnlyBooleanProperty undoStackEmptyProperty() {
+    public ReadOnlyBooleanProperty undoStackEmptyProperty() {
         return undoStackEmptyProperty.getReadOnlyProperty();
     }
     boolean isUndoStackEmpty() {
@@ -155,18 +155,6 @@ public class RichTextAreaViewModel {
     }
     public final void setEditable(boolean value) {
         editableProperty.set(value);
-    }
-
-    // modifiedProperty
-    private final BooleanProperty modifiedProperty = new SimpleBooleanProperty(this, "modified");
-    public final BooleanProperty modifiedProperty() {
-       return modifiedProperty;
-    }
-    public final boolean isModified() {
-       return modifiedProperty.get();
-    }
-    public final void setModified(boolean value) {
-        modifiedProperty.set(value);
     }
 
     // textDecorationProperty
@@ -502,10 +490,6 @@ public class RichTextAreaViewModel {
         redoStackEmptyProperty.set(commandManager.isRedoStackEmpty());
     }
 
-    public FaceModel getCurrentFaceModel() {
-        return new FaceModel(getTextBuffer().getText(), getTextBuffer().getDecorationModelList(), getCaretPosition());
-    }
-
     public void newFaceModel() {
         Platform.runLater(() -> setFaceModel(new FaceModel()));
     }
@@ -515,6 +499,7 @@ public class RichTextAreaViewModel {
     }
 
     public void save() {
-        setFaceModel(getCurrentFaceModel());
+        FaceModel currentFaceModel = new FaceModel(getTextBuffer().getText(), getTextBuffer().getDecorationModelList(), getCaretPosition());
+        Platform.runLater(() -> setFaceModel(currentFaceModel));
     }
 }

--- a/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
@@ -3,10 +3,12 @@ package com.gluonhq.richtext.viewmodel;
 import com.gluonhq.richtext.Selection;
 import com.gluonhq.richtext.Tools;
 import com.gluonhq.richtext.model.Decoration;
+import com.gluonhq.richtext.model.FaceModel;
 import com.gluonhq.richtext.model.ImageDecoration;
 import com.gluonhq.richtext.model.TextBuffer;
 import com.gluonhq.richtext.model.TextDecoration;
 import com.gluonhq.richtext.undo.CommandManager;
+import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
@@ -152,6 +154,18 @@ public class RichTextAreaViewModel {
         editableProperty.set(value);
     }
 
+    // modifiedProperty
+    private final BooleanProperty modifiedProperty = new SimpleBooleanProperty(this, "modified");
+    public final BooleanProperty modifiedProperty() {
+       return modifiedProperty;
+    }
+    public final boolean isModified() {
+       return modifiedProperty.get();
+    }
+    public final void setModified(boolean value) {
+        modifiedProperty.set(value);
+    }
+
     // textDecorationProperty
     private final ObjectProperty<Decoration> decorationProperty = new SimpleObjectProperty<>(this, "decoration") {
         @Override
@@ -170,6 +184,19 @@ public class RichTextAreaViewModel {
     public final void setDecoration(Decoration value) {
         decorationProperty.set(value);
     }
+
+    // faceModelProperty
+    private final ObjectProperty<FaceModel> faceModelProperty = new SimpleObjectProperty<>(this, "faceModel");
+    public final ObjectProperty<FaceModel> faceModelProperty() {
+       return faceModelProperty;
+    }
+    public final FaceModel getFaceModel() {
+       return faceModelProperty.get();
+    }
+    public final void setFaceModel(FaceModel value) {
+        faceModelProperty.set(value);
+    }
+
 
     public RichTextAreaViewModel(BiFunction<Double, Boolean, Integer> getNextRowPosition) {
         this.getNextRowPosition = Objects.requireNonNull(getNextRowPosition);
@@ -470,5 +497,21 @@ public class RichTextAreaViewModel {
     private void updateProperties() {
         undoStackEmptyProperty.set(commandManager.isUndoStackEmpty());
         redoStackEmptyProperty.set(commandManager.isRedoStackEmpty());
+    }
+
+    public FaceModel getCurrentFaceModel() {
+        return new FaceModel(getTextBuffer().getText(), getTextBuffer().getDecorationModelList(), getCaretPosition());
+    }
+
+    public void newFaceModel() {
+        Platform.runLater(() -> setFaceModel(new FaceModel()));
+    }
+
+    public void open(FaceModel faceModel) {
+        Platform.runLater(() -> setFaceModel(faceModel));
+    }
+
+    public void save() {
+        setFaceModel(getCurrentFaceModel());
     }
 }

--- a/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
@@ -32,8 +32,6 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import static com.gluonhq.richtext.model.FaceModel.EMPTY_FACE_MODEL;
-
 public class RichTextAreaViewModel {
 
     public static final Logger LOGGER = Logger.getLogger(RichTextAreaViewModel.class.getName());
@@ -514,14 +512,16 @@ public class RichTextAreaViewModel {
 
     void newFaceModel() {
         Platform.runLater(() -> {
-            setFaceModel(EMPTY_FACE_MODEL);
+            // invalidate faceModelProperty
+            setFaceModel(null);
             setFaceModel(new FaceModel());
         });
     }
 
     void open(FaceModel faceModel) {
         Platform.runLater(() -> {
-            setFaceModel(EMPTY_FACE_MODEL);
+            // invalidate faceModelProperty
+            setFaceModel(null);
             setFaceModel(faceModel);
         });
     }

--- a/src/test/java/com/gluonhq/richtext/undo/CmdManagerTests.java
+++ b/src/test/java/com/gluonhq/richtext/undo/CmdManagerTests.java
@@ -61,8 +61,8 @@ public class CmdManagerTests {
         StringBuilder text = new StringBuilder("Text");
         CommandManager<StringBuilder> commander = new CommandManager<>(text);
         Assertions.assertAll(
-                () -> Assertions.assertTrue(commander.isUndoStackEmpty()),
-                () -> Assertions.assertTrue(commander.isRedoStackEmpty())
+                () -> Assertions.assertEquals(0, commander.getUndoStackSize()),
+                () -> Assertions.assertEquals(0, commander.getRedoStackSize())
         );
     }
 
@@ -72,7 +72,7 @@ public class CmdManagerTests {
         StringBuilder text = new StringBuilder("Text");
         CommandManager<StringBuilder> commander = new CommandManager<>(text);
         commander.execute(new TestCommand());
-        Assertions.assertFalse(commander.isUndoStackEmpty());
+        Assertions.assertNotEquals(0, commander.getUndoStackSize());
     }
 
     @Test
@@ -81,7 +81,7 @@ public class CmdManagerTests {
         StringBuilder text = new StringBuilder("Text");
         CommandManager<StringBuilder> commander = new CommandManager<>(text);
         commander.execute(new TestCommand());
-        Assertions.assertTrue(commander.isRedoStackEmpty());
+        Assertions.assertEquals(0, commander.getRedoStackSize());
     }
 
     @Test
@@ -91,7 +91,7 @@ public class CmdManagerTests {
         CommandManager<StringBuilder> commander = new CommandManager<>(text);
         commander.execute(new TestCommand());
         commander.undo();
-        Assertions.assertTrue(commander.isUndoStackEmpty());
+        Assertions.assertEquals(0, commander.getUndoStackSize());
     }
 
     @Test
@@ -101,7 +101,7 @@ public class CmdManagerTests {
         CommandManager<StringBuilder> commander = new CommandManager<>(text);
         commander.execute(new TestCommand());
         commander.undo();
-        Assertions.assertFalse(commander.isRedoStackEmpty());
+        Assertions.assertNotEquals(0, commander.getRedoStackSize());
     }
 
     @Test
@@ -112,7 +112,7 @@ public class CmdManagerTests {
         commander.execute(new TestCommand());
         commander.undo();
         commander.redo();
-        Assertions.assertTrue(commander.isRedoStackEmpty());
+        Assertions.assertEquals(0, commander.getRedoStackSize());
     }
 
     @Test
@@ -123,7 +123,7 @@ public class CmdManagerTests {
         commander.execute(new TestCommand());
         commander.undo();
         commander.redo();
-        Assertions.assertFalse(commander.isUndoStackEmpty());
+        Assertions.assertNotEquals(0, commander.getUndoStackSize());
     }
 
     @Test


### PR DESCRIPTION
Fixes #108 

This PR adds new/open/save actions to view model, but doesn't use the command manager, so can't be undone, and undo/redo stacks are reset with them.

There is also a modified property that uses a task to compare the current face model with the initial face model every second.