### PR TITLE
Add ParagraphDecoration

### DIFF
--- a/src/main/java/com/gluonhq/Main.java
+++ b/src/main/java/com/gluonhq/Main.java
@@ -26,6 +26,8 @@ import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.Separator;
 import javafx.scene.control.SeparatorMenuItem;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToolBar;
 import javafx.scene.layout.BorderPane;
@@ -194,6 +196,13 @@ public class Main extends Application {
                 createToggleButton(LineAwesomeSolid.ALIGN_CENTER, property -> new ParagraphDecorateAction<>(editor, property, d -> d.getAlignment() == TextAlignment.CENTER, (builder, a) -> builder.alignment(TextAlignment.CENTER).build())),
                 createToggleButton(LineAwesomeSolid.ALIGN_RIGHT, property -> new ParagraphDecorateAction<>(editor, property, d -> d.getAlignment() == TextAlignment.RIGHT, (builder, a) -> builder.alignment(TextAlignment.RIGHT).build())),
                 createToggleButton(LineAwesomeSolid.ALIGN_JUSTIFY, property -> new ParagraphDecorateAction<>(editor, property, d -> d.getAlignment() == TextAlignment.JUSTIFY, (builder, a) -> builder.alignment(TextAlignment.JUSTIFY).build())),
+                new Separator(Orientation.VERTICAL),
+                createSpinner("Spacing", p -> new ParagraphDecorateAction<>(editor, p, v -> (int) v.getSpacing(), (builder, a) -> builder.spacing(a).build())),
+                new Separator(Orientation.VERTICAL),
+                createSpinner("Top", p -> new ParagraphDecorateAction<>(editor, p, v -> (int) v.getTopInset(), (builder, a) -> builder.topInset(a).build())),
+                createSpinner("Right", p -> new ParagraphDecorateAction<>(editor, p, v -> (int) v.getRightInset(), (builder, a) -> builder.rightInset(a).build())),
+                createSpinner("Bottom", p -> new ParagraphDecorateAction<>(editor, p, v -> (int) v.getBottomInset(), (builder, a) -> builder.bottomInset(a).build())),
+                createSpinner("Left", p -> new ParagraphDecorateAction<>(editor, p, v -> (int) v.getLeftInset(), (builder, a) -> builder.leftInset(a).build())),
                 new Separator(Orientation.VERTICAL)
         );
 
@@ -223,7 +232,7 @@ public class Main extends Application {
         root.setTop(new VBox(menuBar, toolbar, paragraphToolbar));
         root.setBottom(statusBar);
 
-        Scene scene = new Scene(root, 960, 480);
+        Scene scene = new Scene(root, 960, 580);
         scene.getStylesheets().add(Main.class.getResource("main.css").toExternalForm());
         stage.titleProperty().bind(Bindings.createStringBinding(() -> "Rich Text Demo" + (editor.isModified() ? " *" : ""), editor.modifiedProperty()));
         stage.setScene(scene);
@@ -249,6 +258,18 @@ public class Main extends Application {
         toggleButton.setGraphic(icon);
         function.apply(toggleButton.selectedProperty().asObject());
         return toggleButton;
+    }
+
+    private HBox createSpinner(String text, Function<ObjectProperty<Integer>, DecorateAction<Integer>> function) {
+        Spinner<Integer> spinner = new Spinner<>();
+        SpinnerValueFactory.IntegerSpinnerValueFactory valueFactory = new SpinnerValueFactory.IntegerSpinnerValueFactory(0, 20);
+        spinner.setValueFactory(valueFactory);
+        spinner.setPrefWidth(80);
+        spinner.setEditable(false);
+        function.apply(valueFactory.valueProperty());
+        HBox spinnerBox = new HBox(5, new Label(text), spinner);
+        spinnerBox.setAlignment(Pos.CENTER);
+        return spinnerBox;
     }
 
     private Button actionImage(Ikon ikon) {

--- a/src/main/java/com/gluonhq/Main.java
+++ b/src/main/java/com/gluonhq/Main.java
@@ -3,10 +3,13 @@ package com.gluonhq;
 import com.gluonhq.richtext.action.Action;
 import com.gluonhq.richtext.RichTextArea;
 import com.gluonhq.richtext.action.DecorateAction;
+import com.gluonhq.richtext.action.ParagraphDecorateAction;
 import com.gluonhq.richtext.action.TextDecorateAction;
 import com.gluonhq.richtext.model.DecorationModel;
 import com.gluonhq.richtext.model.Document;
 import com.gluonhq.richtext.model.ImageDecoration;
+import com.gluonhq.richtext.model.Paragraph;
+import com.gluonhq.richtext.model.ParagraphDecoration;
 import com.gluonhq.richtext.model.TextDecoration;
 import javafx.application.Application;
 import javafx.beans.binding.Bindings;
@@ -33,6 +36,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontPosture;
 import javafx.scene.text.FontWeight;
+import javafx.scene.text.TextAlignment;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import javafx.util.StringConverter;
@@ -78,13 +82,22 @@ public class Main extends Application {
             new DecorationModel(1253, 1059, TextDecoration.builder().presets().build())
     );
 
+    private final List<Paragraph> paragraphDecorations = List.of(
+            new Paragraph(0, 21, ParagraphDecoration.builder().presets().alignment(TextAlignment.CENTER).topInset(6).bottomInset(3).build()),
+            new Paragraph(21, 596, ParagraphDecoration.builder().presets().alignment(TextAlignment.JUSTIFY).topInset(2).bottomInset(2).build()),
+            new Paragraph(596, 614, ParagraphDecoration.builder().presets().alignment(TextAlignment.CENTER).topInset(6).bottomInset(3).build()),
+            new Paragraph(614, 1228, ParagraphDecoration.builder().presets().alignment(TextAlignment.RIGHT).topInset(2).bottomInset(2).build()),
+            new Paragraph(1228, 1253, ParagraphDecoration.builder().presets().alignment(TextAlignment.CENTER).topInset(6).bottomInset(3).build()),
+            new Paragraph(1253, 2017, ParagraphDecoration.builder().presets().alignment(TextAlignment.LEFT).topInset(5).bottomInset(3).spacing(5).build()),
+            new Paragraph(2017, 2312, ParagraphDecoration.builder().presets().alignment(TextAlignment.CENTER).topInset(4).bottomInset(2).build()));
+
     private final Document document = new Document("What is Lorem Ipsum?\n" +
             "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n" +
             "Why do we use it?\n" +
             "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).\n" +
             "Where does it come from?\n" +
             "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of \"de Finibus Bonorum et Malorum\" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, \"Lorem ipsum dolor sit amet..\", comes from a line in section 1.10.32.\nThe standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from \"de Finibus Bonorum et Malorum\" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.\n",
-            decorations, 2312);
+            decorations, paragraphDecorations, 2312);
 
 //    private final List<DecorationModel> decorations = List.of(
 //                new DecorationModel(0, 12, TextDecoration.builder().presets().build()),
@@ -174,6 +187,15 @@ public class Main extends Application {
                 new Separator(Orientation.VERTICAL),
                 editableProp);
 
+        ToolBar paragraphToolbar = new ToolBar();
+        paragraphToolbar.getItems().setAll(
+                createToggleButton(LineAwesomeSolid.ALIGN_LEFT, property -> new ParagraphDecorateAction<>(editor, property, d -> d.getAlignment() == TextAlignment.LEFT, (builder, a) -> builder.alignment(TextAlignment.LEFT).build())),
+                createToggleButton(LineAwesomeSolid.ALIGN_CENTER, property -> new ParagraphDecorateAction<>(editor, property, d -> d.getAlignment() == TextAlignment.CENTER, (builder, a) -> builder.alignment(TextAlignment.CENTER).build())),
+                createToggleButton(LineAwesomeSolid.ALIGN_RIGHT, property -> new ParagraphDecorateAction<>(editor, property, d -> d.getAlignment() == TextAlignment.RIGHT, (builder, a) -> builder.alignment(TextAlignment.RIGHT).build())),
+                createToggleButton(LineAwesomeSolid.ALIGN_JUSTIFY, property -> new ParagraphDecorateAction<>(editor, property, d -> d.getAlignment() == TextAlignment.JUSTIFY, (builder, a) -> builder.alignment(TextAlignment.JUSTIFY).build())),
+                new Separator(Orientation.VERTICAL)
+        );
+
         HBox statusBar = new HBox(10);
         statusBar.getStyleClass().add("status-bar");
         statusBar.setAlignment(Pos.CENTER_RIGHT);
@@ -197,7 +219,7 @@ public class Main extends Application {
 //        menuBar.setUseSystemMenuBar(true);
 
         BorderPane root = new BorderPane(editor);
-        root.setTop(new VBox(menuBar, toolbar));
+        root.setTop(new VBox(menuBar, toolbar, paragraphToolbar));
         root.setBottom(statusBar);
 
         Scene scene = new Scene(root, 960, 480);

--- a/src/main/java/com/gluonhq/Main.java
+++ b/src/main/java/com/gluonhq/Main.java
@@ -8,7 +8,6 @@ import com.gluonhq.richtext.action.TextDecorateAction;
 import com.gluonhq.richtext.model.DecorationModel;
 import com.gluonhq.richtext.model.Document;
 import com.gluonhq.richtext.model.ImageDecoration;
-import com.gluonhq.richtext.model.Paragraph;
 import com.gluonhq.richtext.model.ParagraphDecoration;
 import com.gluonhq.richtext.model.TextDecoration;
 import javafx.application.Application;
@@ -34,8 +33,6 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
-import javafx.scene.text.FontPosture;
-import javafx.scene.text.FontWeight;
 import javafx.scene.text.TextAlignment;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
@@ -73,31 +70,35 @@ public class Main extends Application {
         }
     }
 
-    private final List<DecorationModel> decorations = List.of(
-            new DecorationModel(0, 21, TextDecoration.builder().presets().fontWeight(FontWeight.BOLD).fontSize(14).build()),
-            new DecorationModel(21, 575, TextDecoration.builder().presets().build()),
-            new DecorationModel(596, 18, TextDecoration.builder().presets().fontWeight(FontWeight.BOLD).fontSize(14).build()),
-            new DecorationModel(614, 614, TextDecoration.builder().presets().build()),
-            new DecorationModel(1228, 25, TextDecoration.builder().presets().fontWeight(FontWeight.BOLD).fontSize(14).build()),
-            new DecorationModel(1253, 1059, TextDecoration.builder().presets().build())
-    );
+    private final List<DecorationModel> decorations;
 
-    private final List<Paragraph> paragraphDecorations = List.of(
-            new Paragraph(0, 21, ParagraphDecoration.builder().presets().alignment(TextAlignment.CENTER).topInset(6).bottomInset(3).build()),
-            new Paragraph(21, 596, ParagraphDecoration.builder().presets().alignment(TextAlignment.JUSTIFY).topInset(2).bottomInset(2).build()),
-            new Paragraph(596, 614, ParagraphDecoration.builder().presets().alignment(TextAlignment.CENTER).topInset(6).bottomInset(3).build()),
-            new Paragraph(614, 1228, ParagraphDecoration.builder().presets().alignment(TextAlignment.RIGHT).topInset(2).bottomInset(2).build()),
-            new Paragraph(1228, 1253, ParagraphDecoration.builder().presets().alignment(TextAlignment.CENTER).topInset(6).bottomInset(3).build()),
-            new Paragraph(1253, 2017, ParagraphDecoration.builder().presets().alignment(TextAlignment.LEFT).topInset(5).bottomInset(3).spacing(5).build()),
-            new Paragraph(2017, 2312, ParagraphDecoration.builder().presets().alignment(TextAlignment.CENTER).topInset(4).bottomInset(2).build()));
+    {
+        TextDecoration bold14 = TextDecoration.builder().presets().fontWeight(BOLD).fontSize(14).build();
+        TextDecoration preset = TextDecoration.builder().presets().build();
+        ParagraphDecoration center63 = ParagraphDecoration.builder().presets().alignment(TextAlignment.CENTER).topInset(6).bottomInset(3).build();
+        ParagraphDecoration justify22 = ParagraphDecoration.builder().presets().alignment(TextAlignment.JUSTIFY).topInset(2).bottomInset(2).build();
+        ParagraphDecoration right22 = ParagraphDecoration.builder().presets().alignment(TextAlignment.RIGHT).topInset(2).bottomInset(2).build();
+        ParagraphDecoration left535 = ParagraphDecoration.builder().presets().alignment(TextAlignment.LEFT).topInset(5).bottomInset(3).spacing(5).build();
+        ParagraphDecoration center42 = ParagraphDecoration.builder().presets().alignment(TextAlignment.CENTER).topInset(4).bottomInset(2).build();
+        decorations = List.of(
+                new DecorationModel(0, 21, bold14, center63),
+                new DecorationModel(21, 575, preset, justify22),
+                new DecorationModel(596, 18, bold14, center63),
+                new DecorationModel(614, 614, preset, right22),
+                new DecorationModel(1228, 25, bold14, center63),
+                new DecorationModel(1253, 764, preset, left535),
+                new DecorationModel(2017, 295, preset, center42)
+        );
+    }
 
     private final Document document = new Document("What is Lorem Ipsum?\n" +
             "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.\n" +
             "Why do we use it?\n" +
             "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout. The point of using Lorem Ipsum is that it has a more-or-less normal distribution of letters, as opposed to using 'Content here, content here', making it look like readable English. Many desktop publishing packages and web page editors now use Lorem Ipsum as their default model text, and a search for 'lorem ipsum' will uncover many web sites still in their infancy. Various versions have evolved over the years, sometimes by accident, sometimes on purpose (injected humour and the like).\n" +
             "Where does it come from?\n" +
-            "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of \"de Finibus Bonorum et Malorum\" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, \"Lorem ipsum dolor sit amet..\", comes from a line in section 1.10.32.\nThe standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from \"de Finibus Bonorum et Malorum\" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.\n",
-            decorations, paragraphDecorations, 2312);
+            "Contrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of \"de Finibus Bonorum et Malorum\" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, \"Lorem ipsum dolor sit amet..\", comes from a line in section 1.10.32.\n" +
+            "The standard chunk of Lorem Ipsum used since the 1500s is reproduced below for those interested. Sections 1.10.32 and 1.10.33 from \"de Finibus Bonorum et Malorum\" by Cicero are also reproduced in their exact original form, accompanied by English versions from the 1914 translation by H. Rackham.\n",
+            decorations, 2312);
 
 //    private final List<DecorationModel> decorations = List.of(
 //                new DecorationModel(0, 12, TextDecoration.builder().presets().build()),

--- a/src/main/java/com/gluonhq/richtext/ParagraphTile.java
+++ b/src/main/java/com/gluonhq/richtext/ParagraphTile.java
@@ -1,6 +1,7 @@
 package com.gluonhq.richtext;
 
 import com.gluonhq.richtext.model.Paragraph;
+import com.gluonhq.richtext.model.ParagraphDecoration;
 import com.gluonhq.richtext.viewmodel.RichTextAreaViewModel;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
@@ -24,7 +25,6 @@ import javafx.scene.shape.PathElement;
 import javafx.scene.text.Font;
 import javafx.scene.text.HitInfo;
 import javafx.scene.text.Text;
-import javafx.scene.text.TextAlignment;
 import javafx.scene.text.TextFlow;
 import javafx.util.Duration;
 
@@ -62,7 +62,7 @@ public class ParagraphTile extends HBox {
     private final RichTextAreaViewModel viewModel;
 
     private Paragraph paragraph;
-    private final double textFlowLayoutX, textFlowLayoutY;
+    private double textFlowLayoutX, textFlowLayoutY;
     private final ChangeListener<Number> caretPositionListener = (o, ocp, p) -> updateCaretPosition(p.intValue());
     private final ChangeListener<Selection> selectionListener = (o, os, selection) -> updateSelection(selection);
 
@@ -75,10 +75,6 @@ public class ParagraphTile extends HBox {
         textFlow.setFocusTraversable(false);
         textFlow.getStyleClass().setAll("text-flow");
         textFlow.setOnMousePressed(this::mousePressedListener);
-        // TODO: Expose paragraph justification
-        textFlow.setTextAlignment(TextAlignment.LEFT);
-        // TODO: Expose paragraph spacing
-        textFlow.setLineSpacing(0);
 
         caretShape.setFocusTraversable(false);
         caretShape.getStyleClass().add("caret");
@@ -94,10 +90,6 @@ public class ParagraphTile extends HBox {
         textBackgroundColorPaths.addListener(this::updateLayers);
         // TODO: add left label for list decoration, line number, indentation
         getChildren().add(root);
-        // TODO: expose padding as paragraph indentation
-        setPadding(new Insets(0, 0, 10, 0));
-        textFlowLayoutX = 1d + textFlow.getPadding().getLeft();
-        textFlowLayoutY = 1d + textFlow.getPadding().getTop();
     }
 
     void setParagraph(Paragraph paragraph) {
@@ -107,6 +99,12 @@ public class ParagraphTile extends HBox {
             return;
         }
         this.paragraph = paragraph;
+        ParagraphDecoration decoration = paragraph.getDecoration();
+        textFlow.setTextAlignment(decoration.getAlignment());
+        textFlow.setLineSpacing(decoration.getSpacing());
+        textFlow.setPadding(new Insets(decoration.getTopInset(), decoration.getRightInset(), decoration.getBottomInset(), decoration.getLeftInset()));
+        textFlowLayoutX = 1d + decoration.getLeftInset();
+        textFlowLayoutY = 1d + decoration.getTopInset();
         viewModel.caretPositionProperty().addListener(caretPositionListener);
         viewModel.selectionProperty().addListener(selectionListener);
     }

--- a/src/main/java/com/gluonhq/richtext/action/ParagraphDecorateAction.java
+++ b/src/main/java/com/gluonhq/richtext/action/ParagraphDecorateAction.java
@@ -1,0 +1,63 @@
+package com.gluonhq.richtext.action;
+
+import com.gluonhq.richtext.RichTextArea;
+import com.gluonhq.richtext.model.ParagraphDecoration;
+import javafx.application.Platform;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.value.ChangeListener;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class ParagraphDecorateAction<T> extends DecorateAction<T> {
+
+    private ChangeListener<T> valuePropertyChangeListener;
+    private ChangeListener<ParagraphDecoration> decorationChangeListener;
+    private final Function<ParagraphDecoration, T> function;
+    private final BiFunction<ParagraphDecoration.Builder, T, ParagraphDecoration> builderTFunction;
+
+    public ParagraphDecorateAction(RichTextArea control,
+                                   ObjectProperty<T> valueProperty, Function<ParagraphDecoration, T> valueFunction,
+                                   BiFunction<ParagraphDecoration.Builder, T, ParagraphDecoration> builderTFunction) {
+        super(control, valueProperty);
+        this.function = valueFunction;
+        this.builderTFunction = builderTFunction;
+    }
+
+    @Override
+    protected void bind() {
+        valuePropertyChangeListener = (obs, ov, nv) -> {
+            if (nv != null && !updating) {
+                updating = true;
+                ParagraphDecoration.Builder builder = ParagraphDecoration.builder();
+                if (!viewModel.getSelection().isDefined()) {
+                    builder = builder.fromDecoration(viewModel.getDecorationAtParagraph());
+                }
+                ParagraphDecoration newParagraphDecoration = builderTFunction.apply(builder, nv);
+                Platform.runLater(() ->  {
+                    ACTION_CMD_FACTORY.decorateParagraph(newParagraphDecoration).apply(viewModel);
+                    control.requestFocus();
+                });
+                updating = false;
+            }
+        };
+        valueProperty.addListener(valuePropertyChangeListener);
+        decorationChangeListener = (obs, ov, nv) -> {
+            if (!updating && !nv.equals(ov)) {
+                T newValue = function.apply(nv);
+                if (newValue != null && (ov == null || !newValue.equals(function.apply(ov)))) {
+                    updating = true;
+                    valueProperty.set(newValue);
+                    updating = false;
+                }
+            }
+        };
+        viewModel.decorationAtParagraphProperty().addListener(decorationChangeListener);
+    }
+
+    @Override
+    protected void unbind() {
+        valueProperty.removeListener(valuePropertyChangeListener);
+        viewModel.decorationAtParagraphProperty().removeListener(decorationChangeListener);
+    }
+}

--- a/src/main/java/com/gluonhq/richtext/action/ParagraphDecorateAction.java
+++ b/src/main/java/com/gluonhq/richtext/action/ParagraphDecorateAction.java
@@ -30,7 +30,7 @@ public class ParagraphDecorateAction<T> extends DecorateAction<T> {
             if (nv != null && !updating) {
                 updating = true;
                 ParagraphDecoration.Builder builder = ParagraphDecoration.builder();
-                if (!viewModel.getSelection().isDefined()) {
+                if (!viewModel.getSelection().isDefined() && viewModel.getDecorationAtParagraph() != null) {
                     builder = builder.fromDecoration(viewModel.getDecorationAtParagraph());
                 }
                 ParagraphDecoration newParagraphDecoration = builderTFunction.apply(builder, nv);

--- a/src/main/java/com/gluonhq/richtext/action/TextDecorateAction.java
+++ b/src/main/java/com/gluonhq/richtext/action/TextDecorateAction.java
@@ -30,8 +30,8 @@ public class TextDecorateAction<T> extends DecorateAction<T> {
             if (nv != null && !updating) {
                 updating = true;
                 TextDecoration.Builder builder = TextDecoration.builder();
-                Decoration decoration = viewModel.getDecoration();
-                if (viewModel.getSelection() == Selection.UNDEFINED && decoration instanceof TextDecoration) {
+                Decoration decoration = viewModel.getDecorationAtCaret();
+                if (viewModel.getSelection().isDefined() && decoration instanceof TextDecoration) {
                     builder = builder.fromDecoration((TextDecoration) decoration);
                 }
                 TextDecoration newTextDecoration = builderTFunction.apply(builder, nv);
@@ -53,12 +53,12 @@ public class TextDecorateAction<T> extends DecorateAction<T> {
                 }
             }
         };
-        viewModel.decorationProperty().addListener(decorationChangeListener);
+        viewModel.decorationAtCaretProperty().addListener(decorationChangeListener);
     }
 
     @Override
     protected void unbind() {
         valueProperty.removeListener(valuePropertyChangeListener);
-        viewModel.decorationProperty().removeListener(decorationChangeListener);
+        viewModel.decorationAtCaretProperty().removeListener(decorationChangeListener);
     }
 }

--- a/src/main/java/com/gluonhq/richtext/action/TextDecorateAction.java
+++ b/src/main/java/com/gluonhq/richtext/action/TextDecorateAction.java
@@ -31,7 +31,7 @@ public class TextDecorateAction<T> extends DecorateAction<T> {
                 updating = true;
                 TextDecoration.Builder builder = TextDecoration.builder();
                 Decoration decoration = viewModel.getDecorationAtCaret();
-                if (viewModel.getSelection().isDefined() && decoration instanceof TextDecoration) {
+                if (!viewModel.getSelection().isDefined() && decoration instanceof TextDecoration) {
                     builder = builder.fromDecoration((TextDecoration) decoration);
                 }
                 TextDecoration newTextDecoration = builderTFunction.apply(builder, nv);

--- a/src/main/java/com/gluonhq/richtext/model/DecorationModel.java
+++ b/src/main/java/com/gluonhq/richtext/model/DecorationModel.java
@@ -5,12 +5,15 @@ import java.util.Objects;
 public class DecorationModel {
     private final int start;
     private final int length;
-    private final Decoration decoration;
+    private final Decoration decoration;    // TextDecoration or ImageDecoration
+    private final ParagraphDecoration paragraphDecoration;
 
-    public DecorationModel(int start, int length, Decoration decoration) {
+
+    public DecorationModel(int start, int length, Decoration decoration, ParagraphDecoration paragraphDecoration) {
         this.start = start;
         this.length = length;
         this.decoration = decoration;
+        this.paragraphDecoration = paragraphDecoration;
     }
 
     public int getStart() {
@@ -25,17 +28,23 @@ public class DecorationModel {
         return decoration;
     }
 
+    public ParagraphDecoration getParagraphDecoration() {
+        return paragraphDecoration;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         DecorationModel that = (DecorationModel) o;
-        return start == that.start && length == that.length && decoration.equals(that.decoration);
+        return start == that.start && length == that.length &&
+                decoration.equals(that.decoration) &&
+                paragraphDecoration.equals(that.paragraphDecoration);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(start, length, decoration);
+        return Objects.hash(start, length, decoration, paragraphDecoration);
     }
 
     @Override
@@ -44,6 +53,7 @@ public class DecorationModel {
                 "start=" + start +
                 ", length=" + length +
                 ", decoration=" + decoration +
+                ", paragraphDecoration=" + paragraphDecoration +
                 '}';
     }
 }

--- a/src/main/java/com/gluonhq/richtext/model/Document.java
+++ b/src/main/java/com/gluonhq/richtext/model/Document.java
@@ -10,7 +10,6 @@ public class Document {
 
     private final String text;
     private final List<DecorationModel> decorationList;
-    private final List<Paragraph> paragraphList;
     private final int caretPosition;
 
     public Document() {
@@ -23,15 +22,15 @@ public class Document {
 
     public Document(String text, int caretPosition) {
         this(text,
-                List.of(new DecorationModel(0, text.length(), TextDecoration.builder().presets().build())),
-                List.of(new Paragraph(0, text.length(), ParagraphDecoration.builder().presets().build())),
+                List.of(new DecorationModel(0, text.length(),
+                        TextDecoration.builder().presets().build(),
+                        ParagraphDecoration.builder().presets().build())),
                 caretPosition);
     }
 
-    public Document(String text, List<DecorationModel> decorationList, List<Paragraph> paragraphList, int caretPosition) {
+    public Document(String text, List<DecorationModel> decorationList, int caretPosition) {
         this.text = text;
         this.decorationList = decorationList;
-        this.paragraphList = paragraphList;
         this.caretPosition = caretPosition;
     }
 
@@ -41,10 +40,6 @@ public class Document {
 
     public List<DecorationModel> getDecorationList() {
         return decorationList;
-    }
-
-    public List<Paragraph> getParagraphList() {
-        return paragraphList;
     }
 
     public int getCaretPosition() {
@@ -57,13 +52,12 @@ public class Document {
         if (o == null || getClass() != o.getClass()) return false;
         Document document = (Document) o;
         return Objects.equals(text, document.text) &&
-                Objects.equals(decorationList, document.decorationList) &&
-                Objects.equals(paragraphList, document.paragraphList);
+                Objects.equals(decorationList, document.decorationList);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(text, decorationList, paragraphList, caretPosition);
+        return Objects.hash(text, decorationList, caretPosition);
     }
 
     @Override
@@ -72,8 +66,6 @@ public class Document {
                 "text='" + text.replaceAll("\n", "<n>").replaceAll(ZERO_WIDTH_TEXT, "<a>")  + '\'' +
                 ", decorationList=" + (decorationList == null ? "null" : "{" +
                     decorationList.stream().map(decorationModel -> " - " + decorationModel.toString()).collect(Collectors.joining("\n", "\n", ""))) +
-                ", paragraphDecorationList=" + (paragraphList == null ? "null" : "{" +
-                    paragraphList.stream().map(decorationModel -> " - " + decorationModel.toString()).collect(Collectors.joining("\n", "\n", ""))) +
                 "\n}, caretPosition=" + caretPosition +
                 '}';
     }

--- a/src/main/java/com/gluonhq/richtext/model/Document.java
+++ b/src/main/java/com/gluonhq/richtext/model/Document.java
@@ -10,6 +10,7 @@ public class Document {
 
     private final String text;
     private final List<DecorationModel> decorationList;
+    private final List<Paragraph> paragraphList;
     private final int caretPosition;
 
     public Document() {
@@ -21,12 +22,16 @@ public class Document {
     }
 
     public Document(String text, int caretPosition) {
-        this(text, List.of(new DecorationModel(0, text.length(), TextDecoration.builder().presets().build())), caretPosition);
+        this(text,
+                List.of(new DecorationModel(0, text.length(), TextDecoration.builder().presets().build())),
+                List.of(new Paragraph(0, text.length(), ParagraphDecoration.builder().presets().build())),
+                caretPosition);
     }
 
-    public Document(String text, List<DecorationModel> decorationList, int caretPosition) {
+    public Document(String text, List<DecorationModel> decorationList, List<Paragraph> paragraphList, int caretPosition) {
         this.text = text;
         this.decorationList = decorationList;
+        this.paragraphList = paragraphList;
         this.caretPosition = caretPosition;
     }
 
@@ -38,6 +43,10 @@ public class Document {
         return decorationList;
     }
 
+    public List<Paragraph> getParagraphList() {
+        return paragraphList;
+    }
+
     public int getCaretPosition() {
         return caretPosition;
     }
@@ -47,12 +56,14 @@ public class Document {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Document document = (Document) o;
-        return Objects.equals(text, document.text) && Objects.equals(decorationList, document.decorationList);
+        return Objects.equals(text, document.text) &&
+                Objects.equals(decorationList, document.decorationList) &&
+                Objects.equals(paragraphList, document.paragraphList);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(text, decorationList, caretPosition);
+        return Objects.hash(text, decorationList, paragraphList, caretPosition);
     }
 
     @Override
@@ -61,6 +72,8 @@ public class Document {
                 "text='" + text.replaceAll("\n", "<n>").replaceAll(ZERO_WIDTH_TEXT, "<a>")  + '\'' +
                 ", decorationList=" + (decorationList == null ? "null" : "{" +
                     decorationList.stream().map(decorationModel -> " - " + decorationModel.toString()).collect(Collectors.joining("\n", "\n", ""))) +
+                ", paragraphDecorationList=" + (paragraphList == null ? "null" : "{" +
+                    paragraphList.stream().map(decorationModel -> " - " + decorationModel.toString()).collect(Collectors.joining("\n", "\n", ""))) +
                 "\n}, caretPosition=" + caretPosition +
                 '}';
     }

--- a/src/main/java/com/gluonhq/richtext/model/ImageDecoration.java
+++ b/src/main/java/com/gluonhq/richtext/model/ImageDecoration.java
@@ -59,7 +59,7 @@ public class ImageDecoration implements Decoration {
 
     @Override
     public String toString() {
-        return "ImageDecoration{" +
+        return "IDec{" +
                 "width=" + width +
                 ", height=" + height +
                 ", url='" + url + '\'' +

--- a/src/main/java/com/gluonhq/richtext/model/Paragraph.java
+++ b/src/main/java/com/gluonhq/richtext/model/Paragraph.java
@@ -15,9 +15,12 @@ public class Paragraph {
      */
     private final int end;
 
-    public Paragraph(int start, int end) {
+    private final ParagraphDecoration decoration;
+
+    public Paragraph(int start, int end, ParagraphDecoration decoration) {
         this.start = start;
         this.end = end;
+        this.decoration = decoration;
     }
 
     public int getStart() {
@@ -28,21 +31,27 @@ public class Paragraph {
         return end;
     }
 
+    public ParagraphDecoration getDecoration() {
+        return decoration;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Paragraph paragraph = (Paragraph) o;
-        return start == paragraph.start && end == paragraph.end;
+        return start == paragraph.start &&
+                end == paragraph.end &&
+                Objects.equals(decoration, paragraph.decoration);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(start, end);
+        return Objects.hash(start, end, decoration);
     }
 
     @Override
     public String toString() {
-        return "Paragraph[" + start + ", " + end + ")";
+        return "Paragraph{[" + start + ", " + end + ") " + decoration + "}";
     }
 }

--- a/src/main/java/com/gluonhq/richtext/model/ParagraphDecoration.java
+++ b/src/main/java/com/gluonhq/richtext/model/ParagraphDecoration.java
@@ -65,7 +65,7 @@ public class ParagraphDecoration implements Decoration {
 
     @Override
     public String toString() {
-        return "ParagraphDecoration{" +
+        return "PDec{" +
                 "s=" + spacing +
                 ", a=" + alignment +
                 ", [" + topInset + ", " + rightInset + ", " + bottomInset + ", " + leftInset + "]}";

--- a/src/main/java/com/gluonhq/richtext/model/ParagraphDecoration.java
+++ b/src/main/java/com/gluonhq/richtext/model/ParagraphDecoration.java
@@ -1,0 +1,158 @@
+package com.gluonhq.richtext.model;
+
+import javafx.geometry.Insets;
+import javafx.scene.text.TextAlignment;
+
+import java.util.Objects;
+
+public class ParagraphDecoration implements Decoration {
+
+    private double spacing;
+    private TextAlignment alignment;
+    private double topInset, rightInset, bottomInset, leftInset;
+
+    private ParagraphDecoration() {}
+
+    public double getSpacing() {
+        return spacing;
+    }
+
+    public TextAlignment getAlignment() {
+        return alignment;
+    }
+
+    public double getTopInset() {
+        return topInset;
+    }
+
+    public double getRightInset() {
+        return rightInset;
+    }
+
+    public double getBottomInset() {
+        return bottomInset;
+    }
+
+    public double getLeftInset() {
+        return leftInset;
+    }
+
+    public void setBottomInset(double bottomInset) {
+        this.bottomInset = bottomInset;
+    }
+
+    public static ParagraphDecoration.Builder builder() {
+        return new ParagraphDecoration.Builder();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ParagraphDecoration that = (ParagraphDecoration) o;
+        return Double.compare(that.spacing, spacing) == 0 &&
+                Double.compare(that.topInset, topInset) == 0 &&
+                Double.compare(that.rightInset, rightInset) == 0 &&
+                Double.compare(that.bottomInset, bottomInset) == 0 &&
+                Double.compare(that.leftInset, leftInset) == 0 &&
+                alignment == that.alignment;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(spacing, alignment, topInset, rightInset, bottomInset, leftInset);
+    }
+
+    @Override
+    public String toString() {
+        return "ParagraphDecoration{" +
+                "s=" + spacing +
+                ", a=" + alignment +
+                ", [" + topInset + ", " + rightInset + ", " + bottomInset + ", " + leftInset + "]}";
+    }
+
+    public static class Builder {
+        private double spacing;
+        private TextAlignment alignment;
+        private double topInset, rightInset, bottomInset, leftInset;
+
+        private Builder() {}
+
+        public ParagraphDecoration build() {
+            ParagraphDecoration decoration = new ParagraphDecoration();
+            decoration.spacing = this.spacing;
+            decoration.alignment = this.alignment;
+            decoration.topInset = this.topInset;
+            decoration.rightInset = this.rightInset;
+            decoration.bottomInset = this.bottomInset;
+            decoration.leftInset = this.leftInset;
+            return decoration;
+        }
+
+        public Builder presets() {
+            spacing = 0;
+            alignment = TextAlignment.LEFT;
+            topInset = 0;
+            rightInset = 0;
+            bottomInset = 0;
+            leftInset = 0;
+            return this;
+        }
+
+        public Builder fromDecoration(ParagraphDecoration decoration) {
+            this.spacing = decoration.spacing;
+            this.alignment = decoration.alignment;
+            this.topInset = decoration.topInset;
+            this.rightInset = decoration.rightInset;
+            this.bottomInset = decoration.bottomInset;
+            this.leftInset = decoration.leftInset;
+            return this;
+        }
+
+        public Builder spacing(double spacing) {
+            this.spacing = spacing;
+            return this;
+        }
+
+        public Builder alignment(TextAlignment alignment) {
+            this.alignment = Objects.requireNonNull(alignment);
+            return this;
+        }
+
+        public Builder insets(double topInset, double rightInset, double bottomInset, double leftInset) {
+            this.topInset = topInset;
+            this.rightInset = rightInset;
+            this.bottomInset = bottomInset;
+            this.leftInset = leftInset;
+            return this;
+        }
+
+        public Builder insets(Insets insets) {
+            this.topInset = Objects.requireNonNull(insets).getTop();
+            this.rightInset = insets.getRight();
+            this.bottomInset = insets.getBottom();
+            this.leftInset = insets.getLeft();
+            return this;
+        }
+
+        public Builder topInset(double topInset) {
+            this.topInset = topInset;
+            return this;
+        }
+
+        public Builder rightInset(double rightInset) {
+            this.rightInset = rightInset;
+            return this;
+        }
+
+        public Builder bottomInset(double bottomInset) {
+            this.bottomInset = bottomInset;
+            return this;
+        }
+
+        public Builder leftInset(double leftInset) {
+            this.leftInset = leftInset;
+            return this;
+        }
+    }
+}

--- a/src/main/java/com/gluonhq/richtext/model/Piece.java
+++ b/src/main/java/com/gluonhq/richtext/model/Piece.java
@@ -12,32 +12,25 @@ public final class Piece {
     final BufferType bufferType;
     final int start;                // start position with the buffer
     final int length;               // text length
-//    final int[] lineStops;          // array if line stop indexes
-    final Decoration decoration;
+    final Decoration decoration;    // the piece can contain only a single TextDecoration or ImageDecoration
+    final ParagraphDecoration paragraphDecoration; // the piece can contain only a single ParagraphDecoration,
+                                                   // but it can contain zero, one or more line feed characters
 
     public Piece(final PieceTable source, final BufferType bufferType, final int start, final int length) {
-        this(source, bufferType, start, length, null);
+        this(source, bufferType, start, length, null, null);
     }
 
     public Piece(final PieceTable source, final BufferType bufferType, final int start, final int length, Decoration decoration) {
+        this(source, bufferType, start, length, decoration, null);
+    }
 
+    public Piece(final PieceTable source, final BufferType bufferType, final int start, final int length, Decoration decoration, ParagraphDecoration paragraphDecoration) {
         this.bufferType = bufferType;
         this.start = start;
         this.length = Math.max(length, 0);
         this.source = Objects.requireNonNull(source);
         this.decoration = decoration == null ? TextDecoration.builder().presets().build() : decoration;
-
-
-        // find all the line stops
-//        if (length == 0) {
-//            lineStops = new int[0];
-//        } else {
-//            String text = getText();
-//            lineStops = IntStream
-//                    .range(0, text.length())
-//                    .filter(i -> text.charAt(i) == '\n')
-//                    .toArray();
-//        }
+        this.paragraphDecoration = paragraphDecoration;
     }
 
     public boolean isEmpty() {
@@ -61,18 +54,26 @@ public final class Piece {
         return decoration;
     }
 
+    public ParagraphDecoration getParagraphDecoration() {
+        return paragraphDecoration;
+    }
+
     Piece copy(int newStart, int newLength) {
-        return new Piece(source, bufferType, newStart, newLength, decoration);
+        return new Piece(source, bufferType, newStart, newLength, decoration, paragraphDecoration);
     }
 
     Piece copy(int newStart, int newLength, Decoration newDecoration) {
         if (decoration instanceof TextDecoration) {
             return new Piece(source, bufferType, newStart, newLength,
                     newDecoration instanceof TextDecoration ?
-                            ((TextDecoration) newDecoration).normalize((TextDecoration) decoration) : newDecoration);
+                            ((TextDecoration) newDecoration).normalize((TextDecoration) decoration) : newDecoration, paragraphDecoration);
         } else {
-            return new Piece(source, bufferType, newStart, newLength, decoration);
+            return new Piece(source, bufferType, newStart, newLength, decoration, paragraphDecoration);
         }
+    }
+
+    Piece copy(int newStart, int newLength, Decoration decoration, ParagraphDecoration newParagraphDecoration) {
+        return new Piece(source, bufferType, newStart, newLength, decoration, newParagraphDecoration);
     }
 
     // excludes char at offset
@@ -93,6 +94,7 @@ public final class Piece {
                 ", [" + start +
                 ", " + length +
                 "], " + decoration +
+                ", " + paragraphDecoration +
                 ", \"" + getText().replaceAll("\n", "<n>").replaceAll(TextBuffer.ZERO_WIDTH_TEXT, "<a>") + "\"}";
     }
 }

--- a/src/main/java/com/gluonhq/richtext/model/PieceTable.java
+++ b/src/main/java/com/gluonhq/richtext/model/PieceTable.java
@@ -36,17 +36,13 @@ public final class PieceTable extends AbstractTextBuffer {
     public PieceTable(Document document) {
         this.originalText = Objects.requireNonNull(Objects.requireNonNull(document).getText());
         if (document.getDecorationList() == null) {
-            pieces.add(piece(Piece.BufferType.ORIGINAL, 0, originalText.length()));
+            pieces.add(new Piece(PieceTable.this, Piece.BufferType.ORIGINAL, 0, originalText.length()));
         } else {
             document.getDecorationList().forEach(d ->
-                    pieces.add(new Piece(PieceTable.this, Piece.BufferType.ORIGINAL, d.getStart(), d.getLength(), d.getDecoration())));
+                    pieces.add(new Piece(PieceTable.this, Piece.BufferType.ORIGINAL, d.getStart(), d.getLength(), d.getDecoration(), d.getParagraphDecoration())));
         }
         textLengthProperty.set(pieces.stream().mapToInt(b -> b.length).sum());
         pieceCharacterIterator = new PieceCharacterIterator(this);
-    }
-
-    private Piece piece(Piece.BufferType bufferType, int start, int length ) {
-        return new Piece( this, bufferType, start, length );
     }
 
     /**
@@ -93,7 +89,7 @@ public final class PieceTable extends AbstractTextBuffer {
     @Override
     public List<DecorationModel> getDecorationModelList() {
         return pieces.stream()
-                .map(p -> new DecorationModel(p.start, p.length, p.getDecoration()))
+                .map(p -> new DecorationModel(p.start, p.length, p.getDecoration(), p.getParagraphDecoration()))
                 .collect(Collectors.toList());
     }
 
@@ -140,6 +136,8 @@ public final class PieceTable extends AbstractTextBuffer {
             commander.execute(new TextDecorateCmd(start, end, decoration));
         } else if (decoration instanceof ImageDecoration) {
             commander.execute(new ImageDecorateCmd((ImageDecoration) decoration, start));
+        } else if (decoration instanceof ParagraphDecoration) {
+            commander.execute(new ParagraphDecorateCmd(start, end, (ParagraphDecoration) decoration));
         } else {
             throw new IllegalArgumentException("Decoration type not supported: " + decoration);
         }
@@ -178,6 +176,20 @@ public final class PieceTable extends AbstractTextBuffer {
             textPosition += piece.length;
         }
         return previousPieceDecoration(index);
+    }
+
+    @Override
+    public ParagraphDecoration getParagraphDecorationAtCaret(int caretPosition) {
+        int textPosition = 0;
+        int index = 0;
+        for (; index < pieces.size(); index++) {
+            Piece piece = pieces.get(index);
+            if (textPosition <= caretPosition && caretPosition < textPosition + piece.length) {
+                return piece.getParagraphDecoration();
+            }
+            textPosition += piece.length;
+        }
+        return null;
     }
 
     @Override
@@ -806,6 +818,110 @@ class TextDecorateCmd extends AbstractCommand<PieceTable> {
     public String toString() {
         return "TextDecorateCmd[" + start +
                 " x " + end + "]";
+    }
+}
+
+class ParagraphDecorateCmd extends AbstractCommand<PieceTable> {
+
+    private int start;
+    private int end;
+    private final ParagraphDecoration paragraphDecoration;
+
+    private boolean execSuccess = false;
+    private int pieceIndex = -1;
+    private Collection<Piece> newPieces = new ArrayList<>();
+    private Collection<Piece> oldPieces = new ArrayList<>();
+
+    /**
+     * Decorates the text within the given paragraph with the supplied decoration.
+     * @param start index of the first character to decorate
+     * @param end index of the last character to decorate
+     * @param paragraphDecoration Decorations to apply on the selected paragraph
+     */
+    ParagraphDecorateCmd(int start, int end, ParagraphDecoration paragraphDecoration) {
+        this.start = start;
+        this.end = end;
+        this.paragraphDecoration = paragraphDecoration;
+    }
+
+    @Override
+    protected void doUndo(PieceTable pt) {
+        if (execSuccess) {
+            pt.pieces.addAll(pieceIndex, oldPieces);
+            pt.pieces.removeAll(newPieces);
+
+            oldPieces.forEach(piece -> {
+                pt.fire(new TextBuffer.DecorateEvent(piece.start, piece.start + piece.length, piece.decoration));
+            });
+        }
+    }
+
+    @Override
+    protected void doRedo(PieceTable pt) {
+        if (!PieceTable.inRange(start, 0, pt.getTextLength())) {
+            throw new IllegalArgumentException("Position " + start + " is outside of text bounds [0, " + pt.getTextLength() + ")");
+        }
+
+        //  Accept length larger than actual and adjust it to actual
+        if (end >= pt.getTextLength()) {
+            end = pt.getTextLength();
+        }
+
+        final int[] startPieceIndex = new int[1];
+        final List<Piece> additions = new ArrayList<>(); // start and end pieces
+        final List<Piece> removals = new ArrayList<>();
+
+        pt.walkPieces((piece, pieceIndex, textPosition) -> {
+            if (isPieceInSelection(piece, textPosition)) {
+                startPieceIndex[0] = pieceIndex;
+                if (textPosition <= start) {
+                    int offset = start - textPosition;
+                    int length;
+                    if (textPosition + piece.length > end) {
+                        length = Math.min(end - start, piece.length); // selection ends in current piece
+                    } else {
+                        length = piece.length - offset; // selection spans over next piece(s)
+                    }
+                    if (offset > 0) {
+                        additions.add(piece.pieceBefore(offset));
+                    }
+                    additions.add(piece.copy(piece.start + offset, length, piece.decoration, paragraphDecoration));
+                    if (end < textPosition + piece.length) {
+                        additions.add(piece.pieceFrom(end - textPosition));
+                    }
+                    removals.add(piece);
+                }  else if (textPosition + piece.length <= end) { // entire piece is in selection
+                    additions.add(piece.copy(piece.start, piece.length, piece.decoration, paragraphDecoration));
+                    removals.add(piece);
+                } else if (textPosition < end) {
+                    int offset = end - textPosition;
+                    additions.add(piece.copy(piece.start, offset, piece.decoration, paragraphDecoration));
+                    additions.add(piece.pieceFrom(offset));
+                    removals.add(piece);
+                }
+            }
+            return false;
+        });
+
+        newPieces = PieceTable.normalize(additions);
+        oldPieces = removals;
+        if (newPieces.size() > 0 || oldPieces.size() > 0) {
+            pieceIndex = startPieceIndex[0];
+            pt.pieces.addAll(pieceIndex, newPieces);
+            pt.pieces.removeAll(oldPieces);
+            pt.fire(new TextBuffer.DecorateEvent(start, end, paragraphDecoration));
+            execSuccess = true;
+        }
+    }
+
+    private boolean isPieceInSelection(Piece piece, int textPosition) {
+        int pieceEndPosition = textPosition + piece.length - 1;
+        return start <= pieceEndPosition && (end >= pieceEndPosition || end >= textPosition);
+    }
+
+    @Override
+    public String toString() {
+        return "ParagraphDecorateCmd[" + start + " x " + end + "]";
     }
 }
 

--- a/src/main/java/com/gluonhq/richtext/model/PieceTable.java
+++ b/src/main/java/com/gluonhq/richtext/model/PieceTable.java
@@ -858,7 +858,7 @@ class ParagraphDecorateCmd extends AbstractCommand<PieceTable> {
 
     @Override
     protected void doRedo(PieceTable pt) {
-        if (!PieceTable.inRange(start, 0, pt.getTextLength())) {
+        if (!PieceTable.inRange(start, 0, pt.getTextLength() + 1)) {
             throw new IllegalArgumentException("Position " + start + " is outside of text bounds [0, " + pt.getTextLength() + ")");
         }
 

--- a/src/main/java/com/gluonhq/richtext/model/TextBuffer.java
+++ b/src/main/java/com/gluonhq/richtext/model/TextBuffer.java
@@ -44,6 +44,7 @@ public interface TextBuffer {
 
     Decoration getDecorationAtCaret(int caretPosition);
     void setDecorationAtCaret(TextDecoration decoration);
+    ParagraphDecoration getParagraphDecorationAtCaret(int caretPosition);
 
     interface Event {}
 

--- a/src/main/java/com/gluonhq/richtext/model/TextDecoration.java
+++ b/src/main/java/com/gluonhq/richtext/model/TextDecoration.java
@@ -194,7 +194,7 @@ public class TextDecoration implements Decoration {
 
     @Override
     public String toString() {
-        return "TextDecoration{" +
+        return "TDec{" +
                 "fcolor=" + foreground +
                 ", bcolor=" + background +
                 ", font['" + fontFamily + '\'' +

--- a/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdDecorateParagraph.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdDecorateParagraph.java
@@ -1,0 +1,21 @@
+package com.gluonhq.richtext.viewmodel;
+
+import com.gluonhq.richtext.model.ParagraphDecoration;
+
+import java.util.Objects;
+
+class ActionCmdDecorateParagraph implements ActionCmd {
+
+    private final ParagraphDecoration decoration;
+
+    public ActionCmdDecorateParagraph(ParagraphDecoration decoration) {
+        this.decoration = decoration;
+    }
+
+    @Override
+    public void apply(RichTextAreaViewModel viewModel) {
+        if (viewModel.isEditable()) {
+            viewModel.getCommandManager().execute(new DecorateCmd(Objects.requireNonNull(decoration)));
+        }
+    }
+}

--- a/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdFactory.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/ActionCmdFactory.java
@@ -2,6 +2,7 @@ package com.gluonhq.richtext.viewmodel;
 
 import com.gluonhq.richtext.model.Document;
 import com.gluonhq.richtext.model.ImageDecoration;
+import com.gluonhq.richtext.model.ParagraphDecoration;
 import com.gluonhq.richtext.model.TextDecoration;
 import javafx.scene.input.KeyEvent;
 
@@ -71,6 +72,9 @@ public final class ActionCmdFactory {
         return new ActionCmdDecorateImage(decoration);
     }
 
+    public ActionCmd decorateParagraph(ParagraphDecoration decoration) {
+        return new ActionCmdDecorateParagraph(decoration);
+    }
     public ActionCmd caretMove(RichTextAreaViewModel.Direction direction, KeyEvent event) {
         return new ActionCmdCaretMove(direction, event);
     }

--- a/src/main/java/com/gluonhq/richtext/viewmodel/DecorateCmd.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/DecorateCmd.java
@@ -2,6 +2,7 @@ package com.gluonhq.richtext.viewmodel;
 
 import com.gluonhq.richtext.model.Decoration;
 import com.gluonhq.richtext.model.ImageDecoration;
+import com.gluonhq.richtext.model.ParagraphDecoration;
 import com.gluonhq.richtext.model.TextDecoration;
 
 import java.util.Objects;
@@ -17,18 +18,18 @@ class DecorateCmd extends AbstractEditCmd {
 
     @Override
     public void doRedo(RichTextAreaViewModel viewModel) {
-        if (selection.isDefined() || decoration instanceof ImageDecoration) {
+        if (selection.isDefined() || decoration instanceof ImageDecoration || decoration instanceof ParagraphDecoration) {
             Objects.requireNonNull(viewModel).decorate(decoration);
         } else {
-            prevDecoration = Objects.requireNonNull(viewModel).getDecoration();
-            Objects.requireNonNull(viewModel).setDecoration(decoration);
+            prevDecoration = Objects.requireNonNull(viewModel).getDecorationAtCaret();
+            Objects.requireNonNull(viewModel).setDecorationAtCaret(decoration);
         }
     }
 
     @Override
     public void doUndo(RichTextAreaViewModel viewModel) {
         if (prevDecoration != null && prevDecoration instanceof TextDecoration) {
-            Objects.requireNonNull(viewModel).setDecoration(prevDecoration);
+            Objects.requireNonNull(viewModel).setDecorationAtCaret(prevDecoration);
         }
         Objects.requireNonNull(viewModel).undoDecoration();
     }

--- a/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
@@ -5,6 +5,8 @@ import com.gluonhq.richtext.Tools;
 import com.gluonhq.richtext.model.Decoration;
 import com.gluonhq.richtext.model.Document;
 import com.gluonhq.richtext.model.ImageDecoration;
+import com.gluonhq.richtext.model.Paragraph;
+import com.gluonhq.richtext.model.ParagraphDecoration;
 import com.gluonhq.richtext.model.TextBuffer;
 import com.gluonhq.richtext.model.TextDecoration;
 import com.gluonhq.richtext.undo.CommandManager;
@@ -19,18 +21,26 @@ import javafx.beans.property.ReadOnlyIntegerWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.scene.image.Image;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 
 import java.text.BreakIterator;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 public class RichTextAreaViewModel {
 
@@ -42,6 +52,8 @@ public class RichTextAreaViewModel {
     private BreakIterator wordIterator;
     private int undoStackSizeWhenSaved = 0;
 
+    private final ObservableList<Paragraph> paragraphList = FXCollections.observableArrayList();
+    Paragraph lastParagraph;
     /// PROPERTIES ///////////////////////////////////////////////////////////////
 
     // textBufferProperty
@@ -76,8 +88,9 @@ public class RichTextAreaViewModel {
             if (!hasSelection()) {
                 Decoration decorationAtCaret = getTextBuffer().getDecorationAtCaret(get());
                 if (decorationAtCaret instanceof TextDecoration) {
-                    setDecoration(decorationAtCaret);
+                    setDecorationAtCaret(decorationAtCaret);
                 }
+                getParagraphWithCaret().ifPresent(p -> setDecorationAtParagraph(p.getDecoration()));
             }
         }
     };
@@ -108,7 +121,7 @@ public class RichTextAreaViewModel {
         @Override
         protected void invalidated() {
             if (!get().isDefined()) {
-                setDecoration(getTextBuffer().getDecorationAtCaret(getCaretPosition()));
+                setDecorationAtCaret(getTextBuffer().getDecorationAtCaret(getCaretPosition()));
             }
         }
     };
@@ -165,8 +178,8 @@ public class RichTextAreaViewModel {
         editableProperty.set(value);
     }
 
-    // textDecorationProperty
-    private final ObjectProperty<Decoration> decorationProperty = new SimpleObjectProperty<>(this, "decoration") {
+    // decorationAtCaretProperty
+    private final ObjectProperty<Decoration> decorationAtCaretProperty = new SimpleObjectProperty<>(this, "decorationAtCaret") {
         @Override
         protected void invalidated() {
             if (get() instanceof TextDecoration && !getSelection().isDefined()) {
@@ -174,18 +187,43 @@ public class RichTextAreaViewModel {
             }
         }
     };
-    public final ObjectProperty<Decoration> decorationProperty() {
-       return decorationProperty;
+    public final ObjectProperty<Decoration> decorationAtCaretProperty() {
+       return decorationAtCaretProperty;
     }
-    public final Decoration getDecoration() {
-       return decorationProperty.get();
+    public final Decoration getDecorationAtCaret() {
+       return decorationAtCaretProperty.get();
     }
-    public final void setDecoration(Decoration value) {
-        decorationProperty.set(value);
+    public final void setDecorationAtCaret(Decoration value) {
+        decorationAtCaretProperty.set(value);
+    }
+
+    // decorationAtParagraphProperty
+    private final ObjectProperty<ParagraphDecoration> decorationAtParagraphProperty = new SimpleObjectProperty<>(this, "decorationAtParagraph") {
+        @Override
+        protected void invalidated() {
+        }
+    };
+    public final ObjectProperty<ParagraphDecoration> decorationAtParagraphProperty() {
+        return decorationAtParagraphProperty;
+    }
+    public final ParagraphDecoration getDecorationAtParagraph() {
+        return decorationAtParagraphProperty.get();
+    }
+    public final void setDecorationAtParagraph(ParagraphDecoration value) {
+        decorationAtParagraphProperty.set(value);
     }
 
     // documentProperty
-    private final ObjectProperty<Document> documentProperty = new SimpleObjectProperty<>(this, "document");
+    private final ObjectProperty<Document> documentProperty = new SimpleObjectProperty<>(this, "document") {
+        @Override
+        protected void invalidated() {
+            paragraphList.clear();
+            Document document = get();
+            if (document != null) {
+                paragraphList.addAll(document.getParagraphList());
+            }
+        }
+    };
     public final ObjectProperty<Document> documentProperty() {
        return documentProperty;
     }
@@ -207,6 +245,10 @@ public class RichTextAreaViewModel {
 
     public RichTextAreaViewModel(BiFunction<Double, Boolean, Integer> getNextRowPosition) {
         this.getNextRowPosition = Objects.requireNonNull(getNextRowPosition);
+    }
+
+    public ObservableList<Paragraph> getParagraphList() {
+        return paragraphList;
     }
 
     public final void addChangeListener(Consumer<TextBuffer.Event> listener) {
@@ -246,8 +288,10 @@ public class RichTextAreaViewModel {
         int caretPosition = getCaretPosition();
         if (caretPosition >= getTextLength()) {
             getTextBuffer().append(text);
+            // text (with 0+ LF) appended to last paragraph or as new paragraphs
         } else {
             getTextBuffer().insert(text, caretPosition);
+            // text (with 0+ LF) inserted to some paragraph or as new paragraphs
         }
         moveCaretPosition(text.length());
     }
@@ -278,6 +322,30 @@ public class RichTextAreaViewModel {
             setCaretPosition(-1);
             getTextBuffer().decorate(caretPosition, 1, decoration);
             setCaretPosition(caretPosition + 1);
+        } else if (decoration instanceof ParagraphDecoration) {
+            if (getSelection().isDefined()) {
+                // check all possible paragraphs within selection
+                Selection selection = getSelection();
+                int caretPosition = getCaretPosition();
+                List<Paragraph> changes = getParagraphsWithSelection();
+                clearSelection();
+                setCaretPosition(-1);
+                paragraphList.removeAll(changes);
+                changes.forEach(p -> paragraphList.add(new Paragraph(p.getStart(), p.getEnd(),
+                                    ParagraphDecoration.builder().fromDecoration((ParagraphDecoration) decoration).build())));
+                setCaretPosition(caretPosition);
+                setSelection(selection);
+            } else {
+                // only paragraph where caret is
+                int caretPosition = getCaretPosition();
+                getParagraphWithCaret().ifPresent(p -> {
+                    setCaretPosition(-1);
+                    paragraphList.remove(p);
+                    paragraphList.add(new Paragraph(p.getStart(), p.getEnd(),
+                            ParagraphDecoration.builder().fromDecoration((ParagraphDecoration) decoration).build()));
+                });
+                setCaretPosition(caretPosition);
+            }
         }
     }
 
@@ -391,11 +459,52 @@ public class RichTextAreaViewModel {
 
     public void resetCharacterIterator() {
         getTextBuffer().resetCharacterIterator();
+        updateParagraphList();
         LOGGER.log(Level.FINE, getTextBuffer().toString());
     }
 
     public void walkFragments(BiConsumer<String, Decoration> onFragment, int start, int end) {
         getTextBuffer().walkFragments(onFragment, start, end);
+    }
+
+    private void updateParagraphList() {
+        List<Integer> lineFeeds = getTextBuffer().getLineFeeds();
+        AtomicInteger pos = new AtomicInteger();
+        List<Paragraph> newParagraphList = new ArrayList<>();
+        lineFeeds.forEach(lfPos ->
+                newParagraphList.add(getParagraphAt(pos.getAndSet(lfPos), pos.incrementAndGet())));
+        if (pos.get() <= getTextLength()) {
+            lastParagraph = getParagraphAt(pos.get(), getTextLength());
+            newParagraphList.add(lastParagraph);
+        }
+        paragraphList.setAll(newParagraphList);
+
+    }
+
+    private Paragraph getParagraphAt(int start, int end) {
+        // TODO: check changes in text
+        return paragraphList.stream()
+                .filter(p -> p.getStart() == start && p.getEnd() == end)
+                .findFirst()
+                .orElse(new Paragraph(start, end, ParagraphDecoration.builder().presets().build()));
+    }
+
+    public Optional<Paragraph> getParagraphWithCaret() {
+        int position = getCaretPosition();
+        return paragraphList.stream()
+                .filter(p -> p.getStart() <= position &&
+                        position < (p.equals(lastParagraph) ? p.getEnd() + 1 : p.getEnd()))
+                .findFirst();
+    }
+
+    private List<Paragraph> getParagraphsWithSelection() {
+        Selection selection = getSelection();
+        if (!selection.isDefined()) {
+            return List.of();
+        }
+        return paragraphList.stream()
+                .filter(p -> !(p.getStart() > selection.getEnd() || p.getEnd() <= selection.getStart()))
+                .collect(Collectors.toList());
     }
 
     void undo() {
@@ -509,8 +618,11 @@ public class RichTextAreaViewModel {
         redoStackSizeProperty.set(commandManager.getRedoStackSize());
     }
 
-    public Document getCurrentDocument() {
-        return new Document(getTextBuffer().getText(), getTextBuffer().getDecorationModelList(), getCaretPosition());
+    private Document getCurrentDocument() {
+        List<Paragraph> sortedParagraphList = paragraphList.stream()
+                .sorted(Comparator.comparing(Paragraph::getStart))
+                .collect(Collectors.toList());
+        return new Document(getTextBuffer().getText(), getTextBuffer().getDecorationModelList(), sortedParagraphList, getCaretPosition());
     }
 
     void newDocument() {

--- a/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
+++ b/src/main/java/com/gluonhq/richtext/viewmodel/RichTextAreaViewModel.java
@@ -341,6 +341,7 @@ public class RichTextAreaViewModel {
                 // only paragraph where caret is
                 int caretPosition = getCaretPosition();
                 Paragraph paragraph = getParagraphWithCaret().orElseThrow(() -> new IllegalArgumentException("No paragraph available"));
+                setCaretPosition(-1);
                 getTextBuffer().decorate(paragraph.getStart(), paragraph.getEnd(), decoration);
                 setCaretPosition(caretPosition);
             }


### PR DESCRIPTION
Fixes #126 

By adding a `ParagraphDecoration` to `Piece`, the model can track changes in the text (`TextDecoration`/`ImageDecoration`) but also in the paragraphs (defined between line feeds) which contain those pieces, and actions work as expected for any kind of decoration, including undo/redo support.