### PR TITLE
Commit next development version after successful release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -49,3 +49,16 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           generate_release_notes: true
+
+      - name: Commit next development version
+        if: steps.deploy.outputs.exit_code == 0
+        run: |
+          TAG=${GITHUB_REF/refs\/tags\//}
+          NEW_PROJECT_VERSION=${TAG%.*}.$((${TAG##*.} + 1))
+          echo "Update project version to next snapshot version"
+          mvn versions:set -DnewVersion=$NEW_PROJECT_VERSION-SNAPSHOT -DgenerateBackupPoms=false
+          git commit pom.xml -m "Prepare development of $NEW_PROJECT_VERSION"
+          git push https://gluon-bot:$PAT@github.com/$GITHUB_REPOSITORY HEAD:master
+        shell: bash
+        env:
+          PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
Allow gluon-bot to push next development version. Necessary access has been provided to the bot to push to protected `master` branch