### PR TITLE
artifactId should be rich-text-area rather than rich-text-area-control

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use the RichTextArea control in your project add the following dependency:
     <dependencies>
         <dependency>
             <groupId>com.gluonhq</groupId>
-            <artifactId>rich-text-area-control</artifactId>
+            <artifactId>rich-text-area</artifactId>
             <version>1.0.0</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
There is no rich-text-area-control artifact in the repository
![f9c76d7abf67845cda00c01862600119](https://user-images.githubusercontent.com/5525436/212798292-692eb4a9-424b-4a28-83e4-66a892dcd934.png)