### PR TITLE
Always provide a default not empty decoration

### DIFF
--- a/rta/src/main/java/com/gluonhq/richtextarea/model/DecorationModel.java
+++ b/rta/src/main/java/com/gluonhq/richtextarea/model/DecorationModel.java
@@ -110,4 +110,10 @@ public class DecorationModel implements Serializable {
                 ", paragraphDecoration=" + paragraphDecoration +
                 '}';
     }
+
+    public static DecorationModel createDefaultDecorationModel(int length) {
+        return new DecorationModel(0, length,
+                TextDecoration.builder().presets().build(),
+                ParagraphDecoration.builder().presets().build());
+    }
 }

--- a/rta/src/main/java/com/gluonhq/richtextarea/model/Document.java
+++ b/rta/src/main/java/com/gluonhq/richtextarea/model/Document.java
@@ -63,9 +63,7 @@ public class Document implements Serializable {
 
     public Document(String text, int caretPosition) {
         this(text,
-                List.of(new DecorationModel(0, text.length(),
-                        TextDecoration.builder().presets().build(),
-                        ParagraphDecoration.builder().presets().build())),
+                List.of(DecorationModel.createDefaultDecorationModel(text.length())),
                 caretPosition);
     }
 

--- a/rta/src/main/java/com/gluonhq/richtextarea/model/PieceTable.java
+++ b/rta/src/main/java/com/gluonhq/richtextarea/model/PieceTable.java
@@ -252,6 +252,10 @@ public final class PieceTable extends AbstractTextBuffer {
                 return (end <= tp);
             });
         }
+        if (mergedList.isEmpty()) {
+            // provide a default decoration
+            mergedList.add(DecorationModel.createDefaultDecorationModel(0));
+        }
         return mergedList;
     }
 

--- a/rta/src/test/java/com/gluonhq/richtextarea/ui/RTATest.java
+++ b/rta/src/test/java/com/gluonhq/richtextarea/ui/RTATest.java
@@ -172,6 +172,68 @@ public class RTATest {
     }
 
     @Test
+    public void emptyDocumentDemoTest(FxRobot robot) {
+        run(() -> {
+            String text = "Hello RTA";
+            Document document = new Document(text);
+            richTextArea.getActionFactory().open(document).execute(new ActionEvent());
+        });
+        waitForFxEvents();
+
+        verifyThat(".rich-text-area", node -> node instanceof RichTextArea);
+        verifyThat(".rich-text-area", NodeMatchers.isFocused());
+        RichTextArea rta = robot.lookup(".rich-text-area").query();
+        assertEquals(9, rta.getTextLength());
+        assertEquals(9, rta.getCaretPosition());
+
+        Document document = rta.getDocument();
+        assertNotNull(document);
+        assertEquals(0, document.getCaretPosition());
+        assertEquals("Hello RTA", document.getText());
+        assertNotNull(document.getDecorations());
+        assertEquals(1, document.getDecorations().size());
+        assertInstanceOf(TextDecoration.class, document.getDecorations().get(0).getDecoration());
+        TextDecoration td = (TextDecoration) document.getDecorations().get(0).getDecoration();
+        assertEquals("black", td.getForeground());
+        assertEquals("transparent", td.getBackground());
+        assertEquals("System", td.getFontFamily());
+        assertEquals(14, td.getFontSize());
+        assertEquals(NORMAL, td.getFontWeight());
+        assertEquals(REGULAR, td.getFontPosture());
+
+        robot.push(new KeyCodeCombination(A, SHORTCUT_DOWN));
+        waitForFxEvents();
+        run(() -> {
+            richTextArea.getActionFactory().cut().execute(new ActionEvent());
+            richTextArea.getActionFactory().save().execute(new ActionEvent());
+        });
+        waitForFxEvents();
+        Document emptyDocument = rta.getDocument();
+
+        assertEquals(0, rta.getTextLength());
+        assertEquals(0, rta.getCaretPosition());
+        assertNotNull(emptyDocument);
+        assertEquals(0, emptyDocument.getCaretPosition());
+        assertEquals("", emptyDocument.getText());
+        assertNotNull(emptyDocument.getDecorations());
+        assertEquals(1, emptyDocument.getDecorations().size());
+
+        run(() -> richTextArea.getActionFactory().open(emptyDocument).execute(new ActionEvent()));
+        waitForFxEvents();
+
+        document = rta.getDocument();
+        assertEquals(0, rta.getTextLength());
+        assertEquals(0, rta.getCaretPosition());
+        assertNotNull(document);
+        assertEquals(emptyDocument, document);
+        assertEquals(0, document.getCaretPosition());
+        assertEquals("", document.getText());
+        assertNotNull(document.getDecorations());
+        assertEquals(1, document.getDecorations().size());
+
+    }
+
+    @Test
     public void basicDocumentDemoTest(FxRobot robot) {
         run(() -> {
             String text = "Hello RTA";


### PR DESCRIPTION
Fixes #343 

After #322, `PieceTable:: getDecorationModelList` returns an empty decoration model list if the document is empty, which leads to NPEs, as there was always a the default piece with decorations and no NPE checks are in place.