### PR TITLE
Fixes to import RTA control with Scene Builder

### DIFF
--- a/rta/src/main/java/com/gluonhq/richtextarea/ParagraphTile.java
+++ b/rta/src/main/java/com/gluonhq/richtextarea/ParagraphTile.java
@@ -80,7 +80,7 @@ import java.util.stream.Stream;
 
 import static com.gluonhq.richtextarea.model.TableDecoration.TABLE_SEPARATOR;
 
-public class ParagraphTile extends HBox {
+class ParagraphTile extends HBox {
 
     private static final double INDENT_PADDING = 20.0;
 

--- a/rta/src/main/java/com/gluonhq/richtextarea/RichTextArea.java
+++ b/rta/src/main/java/com/gluonhq/richtextarea/RichTextArea.java
@@ -76,7 +76,11 @@ import java.util.function.Function;
 public class RichTextArea extends Control {
 
     public static final String STYLE_CLASS = "rich-text-area";
-    public static final DataFormat RTA_DATA_FORMAT = new DataFormat("text/rich-text-area");
+    public static final DataFormat RTA_DATA_FORMAT;
+    static {
+        DataFormat dataFormat = DataFormat.lookupMimeType("text/rich-text-area");
+        RTA_DATA_FORMAT = dataFormat == null ? new DataFormat("text/rich-text-area") : dataFormat;
+    }
     private static final PseudoClass PSEUDO_CLASS_READONLY = PseudoClass.getPseudoClass("readonly");
 
     private final ActionFactory actionFactory = new ActionFactory(this);


### PR DESCRIPTION
Fixes #291 

It needs Scene Builder PR: https://github.com/gluonhq/scenebuilder/pull/702 to avoid (non-critical) exceptions, when importing package-private controls.

It moves `ParagraphTile` from public to package-private, in line with other controls used internally by the skin. I don't think this is an API change, as this control wasn't meant por public usage and it didn't have any public API itself.