### PR TITLE
Do not start the caret animation unless its layer is part of the SG.

### DIFF
--- a/rta/src/main/java/com/gluonhq/richtextarea/ParagraphTile.java
+++ b/rta/src/main/java/com/gluonhq/richtextarea/ParagraphTile.java
@@ -598,7 +598,9 @@ class ParagraphTile extends HBox {
                         caretShape.getElements().add(new LineTo(originX, caretSize));
                     }
                     richTextAreaSkin.lastValidCaretPosition = caretPosition;
-                    caretTimeline.play();
+                    if (getScene() != null) {
+                        caretTimeline.play();
+                    }
                     updateCaretOrigin();
                 }
             }


### PR DESCRIPTION
Fixes a memory leak.
Fix #437